### PR TITLE
Avoid unsupported reasoning effort in ACP startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -16,5 +24,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm audit --audit-level=high
+      - run: npm run compile
       - run: npm test
       - run: npm run package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **Reasoning effort is now compatibility-gated for ACP startup.** `grok.defaultEffort` is still saved, but current `grok-build` ACP sessions start with the CLI default effort because `reasoningEffort` is rejected by the backend. This prevents the sidebar from crashing with `Grok exited (code 2)` after selecting an effort level such as Max.
+- **Regression coverage for effort startup.** Added pure argument-builder coverage and a fake-CLI ACP integration case that fails if `--reasoning-effort` is forwarded to `grok agent stdio`.
+
 ## 1.2.0 — 2026-05-28
 
 ### Plan mode is now enabled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ VS Code sidebar extension for **xAI's Grok Build CLI**, driven by `grok agent st
 
 ## Status
 
-v1.2.0 (local; 1.0.3 is the latest published on the VS Code Marketplace). 178 tests passing, all grok-free (CI never spawns the binary; grok-dependent probes live separately in `research/*.cjs`). Smoke-tested end-to-end against `grok` v0.1.211 on Linux and Windows-via-WSL, and against the **native Windows build** `grok` 0.2.3 (`irm https://x.ai/cli/install.ps1 | iex`) — `cli-locator` resolves `grok.cmd`/`grok.exe` and `terminal-manager` uses `shell:true`. The native-Windows smoke test surfaced a handful of webview regressions (history popover that never closed, session rows only clickable on the label, reasoning traces no longer expandable, a cluttered welcome screen), all fixed in this build. Plan mode is now **enabled** and enforced client-side (see `research/plan-mode.md` § Resolution).
+v1.2.0 (local; 1.0.3 is the latest published on the VS Code Marketplace). 186 tests passing, all grok-free (CI never spawns the binary; grok-dependent probes live separately in `research/*.cjs`). Smoke-tested end-to-end against `grok` v0.1.211 on Linux and Windows-via-WSL, and against the **native Windows build** `grok` 0.2.3 (`irm https://x.ai/cli/install.ps1 | iex`) — `cli-locator` resolves `grok.cmd`/`grok.exe` and `terminal-manager` uses `shell:true`. The native-Windows smoke test surfaced a handful of webview regressions (history popover that never closed, session rows only clickable on the label, reasoning traces no longer expandable, a cluttered welcome screen), all fixed in this build. Plan mode is now **enabled** and enforced client-side (see `research/plan-mode.md` § Resolution).
 
 ## Module map
 
@@ -33,7 +33,7 @@ Pure modules (`acp-dispatch`, `chips`, `prompt-builder`, `slash-filter`, `cli-lo
 
 ```bash
 npm install
-npm test         # 178 tests, ~1.4s, vitest — all grok-free (incl. happy-dom DOM tests + fake-CLI ACP integration tests)
+npm test         # 186 tests, ~1.4s, vitest — all grok-free (incl. happy-dom DOM tests + fake-CLI ACP integration tests)
 npm run package  # → grok-vscode-phuryn-1.2.0.vsix
 ```
 
@@ -54,7 +54,7 @@ See `README.md § Install` for the full per-platform matrix.
 - `session/request_permission` → chat card with `allow-always` / `allow-once` / `reject-once`, diff editor preview for `kind:"edit"`
 - `session/set_mode` wired; the picker exposes **Agent**, **Plan**, and **YOLO**. The CLI's non-plan mode id is `"default"` (not `"agent"`), captured as `ACT_MODE_ID` in `sidebar.ts`.
 - **Plan mode is enforced client-side** (mirror of YOLO). The CLI's `x.ai/exit_plan_mode` still treats any client response — result *or* error — as approval (re-verified broken in 0.2.3), so we don't rely on it. Instead `src/plan-gate.ts` gates the two *mandatory* server→client choke points: `fs/write_text_file` (block writes resolving inside the workspace cwd) and `terminal/create` (block anything not on the read-only allowlist). grok's own `~/.grok/sessions/<…>/plan.md` write lands *outside* the workspace and is allowed (and snooped to recover the plan text — `exit_plan_mode` arrives with `planContent: null`). Approve → drop the gate + send an "implement it now" follow-up prompt; Keep planning → gate stays up. Entering plan mode *any* way (incl. agent-initiated `current_mode_update: plan`) raises the gate; it's lowered only by explicit user action, never auto-lowered by CLI mode flapping. For the full pedagogical course with diagrams and hands-on guidance, see `research/understanding-plan-mode.md`.
-- `--reasoning-effort` flag at agent spawn (`low | medium | high | xhigh | max`)
+- `grok.defaultEffort` is saved for future support, but current grok-build ACP sessions start with the CLI default effort because the backend rejects `reasoningEffort`.
 - `available_commands_update` → slash autocomplete
 - `current_mode_update` → bottom-toolbar mode button (the top bar was removed in 0.9.0)
 - `_meta.totalTokens` → context donut
@@ -90,5 +90,5 @@ Per-release: bump version in `package.json`, `npm test`, `npm run publish`. The 
 - Commits explain the *why*, not the *what*
 - Don't introduce abstractions speculatively
 - Don't add comments that explain what well-named code already says
-- 178 tests is the floor — every PR should keep that green. All tests are grok-free (no binary spawn); grok-dependent probes live in `research/*.cjs` and are run manually, never by `npm test` or CI
+- 186 tests is the floor — every PR should keep that green. All tests are grok-free (no binary spawn); grok-dependent probes live in `research/*.cjs` and are run manually, never by `npm test` or CI
 - **Version bumps are user-initiated.** Iterate at the current version (rebuild the same vsix and reinstall locally) until the user says to bump and publish. Don't bump `package.json` on your own.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ When the panel opens (or you click **+** for a new session):
 1. Locate the `grok` binary: `grok.cliPath` setting → `~/.grok/bin/grok` → `PATH`.
 2. Spawn `grok agent stdio` as a background child — visible in `ps` / Activity Monitor, never opens a terminal window.
 3. Send `initialize` → `session/new` → `session/set_model` over stdio.
-4. If `grok.defaultEffort` is set, pass `--reasoning-effort <level>` at spawn time.
+4. If `grok.defaultEffort` is set, keep it saved for future ACP support but start with the CLI default effort; current `grok-build` ACP sessions reject `reasoningEffort`.
 5. Stream `session/update` notifications (messages, thoughts, tool calls, permission requests) back to the chat.
 
 ### Module map
@@ -187,7 +187,7 @@ Each action appears in chat:
 
 ### Reasoning effort
 
-Click the **gear** icon → effort dots to choose Low → Max. Changing effort restarts the session with `--reasoning-effort <level>`. If chat history exists, a dialog offers **Summarize & Restart** (asks Grok for a summary, starts a fresh session, sends the summary as context) or **Just Restart** (discards).
+Click the **gear** icon → effort dots to save a preferred effort level. Current `grok-build` ACP sessions use the CLI default effort because the backend rejects `reasoningEffort`; the saved preference is retained for future CLI/model support and does not restart the session.
 
 ### Model picker
 
@@ -226,7 +226,7 @@ Or edit the config files directly via gear → *Open global config* / *Open proj
 |---|---|---|
 | `grok.cliPath` | `""` | Path to the `grok` binary. Empty = auto-discover (`~/.grok/bin/grok` → PATH). |
 | `grok.defaultModel` | `""` | Model ID for new sessions. Empty = CLI default. |
-| `grok.defaultEffort` | `""` | Reasoning effort (`low` / `medium` / `high` / `xhigh` / `max`). Empty = CLI default. Changing this restarts the session. |
+| `grok.defaultEffort` | `""` | Saved reasoning effort preference (`low` / `medium` / `high` / `xhigh` / `max`). Current `grok-build` ACP sessions start with the CLI default effort because `reasoningEffort` is rejected by the backend. |
 | `grok.includeActiveFileByDefault` | `true` | Auto-add the active editor as a context chip. |
 | `grok.useCtrlEnterToSend` | `false` | When true, Enter inserts a newline and Ctrl/Cmd+Enter sends. |
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -2,7 +2,7 @@
 
 Two layers:
 
-1. **Grok-free automated tests** (Vitest) — pure-logic unit tests plus happy-dom DOM tests that drive the real `media/chat.js`, plus a fast TerminalManager suite that spawns real `/bin/sh` children. **178 tests, all passing in ~1.4s.** Listed below. **None of them spawn the `grok` binary**, so the whole suite runs in CI on a clean Ubuntu box (`.github/workflows/ci.yml` runs `npm ci && npm test && npm run package` and never installs grok).
+1. **Grok-free automated tests** (Vitest) — pure-logic unit tests plus happy-dom DOM tests that drive the real `media/chat.js`, plus a fast TerminalManager suite that spawns real `/bin/sh` children. **186 tests, all passing in ~1.4s.** Listed below. **None of them spawn the `grok` binary**, so the whole suite runs in CI on a clean Ubuntu box (`.github/workflows/ci.yml` runs `npm ci && npm test && npm run package` and never installs grok).
 2. **VS Code integration tests** (deferred to v0.2 with `@vscode/test-electron`) — covers command registration, view lifecycle, settings reads, and the diff editor. Deferred because they require a headed VS Code, are slow, and the modules already cover the bug-prone surface.
 
 Separately, **grok-dependent probes** live as standalone scripts under `research/*.cjs`. They exercise the real CLI's ACP behavior (e.g. confirming `exit_plan_mode` treats any client reply as approval) and are run **manually** — Vitest's `include` glob is `test/**/*.test.ts`, so it never collects them. They're non-destructive (ACK writes without touching disk and run in a temp cwd) and require a `grok` binary on PATH; CI doesn't run them.
@@ -105,7 +105,7 @@ Shared between the shipped webview and the tests (`media/webview-helpers.js`).
 - File-ref detection: recognizes `@path` mentions and bare path-looking tokens, ignores prose
 - Relative-time formatting: "just now" / "Nm" / "Nh" / "Nd" buckets, singular/plural, far-future and far-past edges
 
-### `test/plan-card.dom.test.ts` — plan card in a real DOM (8 tests)
+### `test/plan-card.dom.test.ts` — plan card in a real DOM (10 tests)
 
 happy-dom test (see [Webview DOM tests](#webview-dom-tests) below). Drives the shipped `media/chat.js`, dispatches the messages `sidebar.ts` posts, clicks the rendered buttons, asserts on the `postMessage` payload that goes back to the host.
 
@@ -117,11 +117,17 @@ happy-dom test (see [Webview DOM tests](#webview-dom-tests) below). Drives the s
 - `planNotice` / `planBlocked` (command + write variants) render a `.plan-notice` with the right text
 - Read-only plan-history card renders with the persisted verdict label
 
-### `test/acp-integration.test.ts` — ACP wire layer + plan-mode gate (6 tests)
+### `test/acp.test.ts` — ACP client helpers (2 tests)
+
+- **Spawn argv** — `buildGrokAgentArgs` always returns `["agent", "stdio"]`.
+- **Effort compatibility** — setting `grok.defaultEffort` does not add `--reasoning-effort` to ACP startup, preventing the code-2 crash seen with current `grok-build` backends.
+
+### `test/acp-integration.test.ts` — ACP wire layer + plan-mode gate (7 tests)
 
 Spawns the fake `grok agent stdio` from `test/fixtures/fake-grok-acp.cjs` (a ~150-line ACP server encoding only what the protocol requires, not grok version quirks) and drives `src/acp.ts` AcpClient against it over real JSON-RPC stdio. Cross-platform: `.cmd` wrapper on Windows, `.sh` wrapper elsewhere; subprocess startup adds ~50–100ms per test (same order as terminal-manager).
 
 - **Lifecycle** — spawn → initialize → session/new succeeds; a basic prompt round-trips with `_meta.totalTokens`.
+- **Startup effort compatibility** — with `effort:"max"` configured, the fake CLI still receives `agent stdio` and the client logs that effort was not forwarded.
 - **Plan-snoop** — grok's plan.md write (outside the workspace) is allowed AND emits `planFileContent` with the snooped text; the host's `exitPlanRequest` event fires with that content; the file actually lands on disk.
 - **Workspace-write gate** — with `planActive=true`, `fs/write_text_file` for a path inside the workspace is refused with PLAN_BLOCKED, emits `mutationBlocked`, no file lands.
 - **Workspace-write gate (off)** — with `planActive=false`, the same write succeeds end-to-end.
@@ -136,7 +142,7 @@ Pure helpers extracted into [src/plan-restore.ts](src/plan-restore.ts) specifica
 - **`decideRestoreState`** — given the saved log, returns whether to raise the gate and what mode to set on the CLI. Last verdict `rejected` → restore Plan mode; `approved`/`abandoned` → Agent mode; no log / undefined → Agent mode (legacy session, safe default)
 - **End-to-end scenarios** — user rejects then closes VS Code → restore in Plan mode; rejects then approves → Agent mode; rejects then cancels → Agent mode (the regression where Cancel kept restoring into Plan mode); legacy session → Agent mode with no surprise gate
 
-### `test/plan-history-restore.dom.test.ts` — plan-history restore rendering (12 tests)
+### `test/plan-history-restore.dom.test.ts` — plan-history restore rendering (15 tests)
 
 happy-dom test driving the shipped webview through a `planHistoryQueue` + `session/load` replay sequence. This is the visual side of the state machine — what actually renders, in what order, after the host sends saved plans plus a stream of replayed messages.
 

--- a/package.json
+++ b/package.json
@@ -171,14 +171,14 @@
           ],
           "enumDescriptions": [
             "CLI default (no flag passed to grok agent stdio)",
-            "Low — faster, lighter reasoning",
-            "Medium",
-            "High",
-            "XHigh",
-            "Max — deepest reasoning, slowest"
+            "Low — saved for future ACP support",
+            "Medium — saved for future ACP support",
+            "High — saved for future ACP support",
+            "XHigh — saved for future ACP support",
+            "Max — saved for future ACP support"
           ],
           "default": "",
-          "description": "Reasoning effort passed as --reasoning-effort to grok agent stdio. Changing this restarts the session."
+          "description": "Saved reasoning effort preference. Current grok-build ACP sessions start with the CLI default effort because reasoningEffort is rejected by the backend."
         },
         "grok.useCtrlEnterToSend": {
           "type": "boolean",

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -91,6 +91,14 @@ export interface TerminalHandler {
 
 type Pending = { resolve: (v: any) => void; reject: (e: any) => void };
 
+export function buildGrokAgentArgs(_effort?: EffortLevel): string[] {
+  // Current grok-build ACP sessions reject reasoningEffort. Passing it after
+  // `agent` exits with code 2; passing it globally reaches the backend but is
+  // rejected by the model. Keep the user setting persisted, but start stdio
+  // sessions with the CLI default effort until the ACP path supports it.
+  return ["agent", "stdio"];
+}
+
 export class AcpClient extends EventEmitter {
   private proc?: ChildProcessWithoutNullStreams;
   private rl?: Interface;
@@ -122,11 +130,10 @@ export class AcpClient extends EventEmitter {
   }
 
   async start(): Promise<void> {
-    const args: string[] = ["agent"];
+    const args = buildGrokAgentArgs(this.opts.effort);
     if (this.opts.effort) {
-      args.push("--reasoning-effort", this.opts.effort);
+      this.opts.log(`grok.defaultEffort=${this.opts.effort} is saved but not forwarded because grok-build ACP sessions currently reject reasoningEffort`);
     }
-    args.push("stdio");
 
     this.opts.log(`spawning ${this.opts.cliPath} ${args.join(" ")} (cwd=${this.opts.cwd})`);
     // Node 18+ refuses to spawn .cmd/.bat without `shell: true` on Windows

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -840,56 +840,10 @@ See design doc for the full state machine diagram.`;
       case "setEffort": {
         const newLevel = msg.level;
         const cfg2 = vscode.workspace.getConfiguration("grok");
-
-        if (!this.hasHistory || !this.client) {
-          await cfg2.update("defaultEffort", newLevel, vscode.ConfigurationTarget.Global);
-          await this.startSession();
-          break;
-        }
-
-        const choice = await vscode.window.showInformationMessage(
-          "Changing reasoning effort requires restarting the session.",
-          "Summarize & Restart",
-          "Just Restart",
-        );
-        if (!choice) break; // dismissed
-
         await cfg2.update("defaultEffort", newLevel, vscode.ConfigurationTarget.Global);
-
-        if (choice === "Just Restart") {
-          this.post({ type: "clearMessages" });
-          await this.startSession();
-          break;
-        }
-
-        // "Summarize & Restart": silently capture summary, inject as context in new session
-        const currentClient = this.client;
-        this.post({ type: "summarizing" });
-        const chunks: string[] = [];
-        const captureChunk = (t: string) => chunks.push(t);
-        currentClient.on("messageChunk", captureChunk);
-        this.suppressContent = true;
-        try {
-          await currentClient.prompt(
-            "Summarize our conversation so far in a concise paragraph. Be brief.",
-          );
-        } catch { /* best effort */ } finally {
-          currentClient.off("messageChunk", captureChunk);
-          this.suppressContent = false;
-        }
-        const summary = chunks.join("").trim();
-
-        await this.startSession(); // resets suppressContent to false
-
-        if (summary && this.client) {
-          this.post({ type: "sessionContext" });
-          this.suppressContent = true;
-          try {
-            await this.client.prompt(`[Context from previous session]\n${summary}`);
-          } catch { /* best effort */ } finally {
-            this.suppressContent = false;
-          }
-        }
+        void vscode.window.showInformationMessage(
+          "Grok Build ACP sessions currently use the CLI default effort; this setting is saved for future support.",
+        );
         break;
       }
       case "openGlobalConfig": {

--- a/test/acp-integration.test.ts
+++ b/test/acp-integration.test.ts
@@ -118,6 +118,34 @@ describe("ACP integration (real subprocess, fake CLI)", () => {
     expect(meta).toMatchObject({ totalTokens: 10 });
   });
 
+  it("startup: configured default effort is not forwarded to grok-build ACP stdio", async () => {
+    const logs: string[] = [];
+    const effortClient = new AcpClient({
+      cliPath: fixtureCli(),
+      cwd: workspace,
+      env: {
+        ...process.env,
+        FAKE_WORKSPACE_ROOT: workspace,
+        FAKE_PLAN_PATH: path.join(planHome, ".grok", "sessions", "cwd-x", "sess-effort", "plan.md"),
+      },
+      effort: "max",
+      log: (msg) => logs.push(msg),
+    });
+
+    try {
+      await effortClient.start();
+      await effortClient.newSession();
+
+      expect(effortClient.sessionId).toBe("fake-session-1");
+      expect(logs.join("\n")).toContain("not forwarded");
+      expect(logs.join("\n")).toContain("spawning");
+      expect(logs.join("\n")).toContain("agent stdio");
+      expect(logs.join("\n")).not.toContain("--reasoning-effort");
+    } finally {
+      effortClient.dispose();
+    }
+  });
+
   it("plan-snoop: grok's plan.md write is allowed AND emits planFileContent with the text", async () => {
     client.planActive = true; // gate is up, but plan.md (outside workspace) must still be allowed
     const planFireP = waitFor<string>(client, "planFileContent");

--- a/test/acp.test.ts
+++ b/test/acp.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { buildGrokAgentArgs } from "../src/acp";
+
+describe("buildGrokAgentArgs", () => {
+  it("starts ACP sessions with the stdio subcommand", () => {
+    expect(buildGrokAgentArgs()).toEqual(["agent", "stdio"]);
+  });
+
+  it("does not forward defaultEffort to grok-build ACP startup", () => {
+    expect(buildGrokAgentArgs("max")).toEqual(["agent", "stdio"]);
+  });
+});

--- a/test/fixtures/fake-grok-acp.cjs
+++ b/test/fixtures/fake-grok-acp.cjs
@@ -17,6 +17,13 @@
 // whichever way the host replies to exit_plan_mode.
 
 const readline = require("readline");
+
+const argv = process.argv.slice(2);
+if (argv.join(" ") !== "agent stdio") {
+  process.stderr.write(`unexpected argv: ${JSON.stringify(argv)}\n`);
+  process.exit(2);
+}
+
 const rl = readline.createInterface({ input: process.stdin });
 
 let nextId = 1000;


### PR DESCRIPTION
## Summary

Fixes #3.

- stop forwarding `grok.defaultEffort` as `--reasoning-effort` during `grok agent stdio` startup because current `grok-build` ACP sessions reject `reasoningEffort`
- save effort selections for future support and show a user-facing notice instead of restarting/crashing the session
- add pure argv coverage plus a fake-CLI ACP regression test that fails on unexpected startup args
- tighten CI with read-only permissions, concurrency cancellation, an explicit compile step, timeout, and a high-severity npm audit gate
- update README/TESTS/CLAUDE/package metadata/changelog so docs match current behavior

## Verification

- `npm ci`
- `npm audit --audit-level=high` (passes; existing advisory output is moderate-only and would require a breaking Vitest major upgrade)
- `npm run compile`
- `npm test` (186 passed)
- `npm run package`

## Notes

I did not bump the extension version. The repo guidance says version bumps are user-initiated.
