### PR TITLE
Harden plan-mode gate for relative writes and mutating commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Plan-mode gate hardening.** Relative workspace write paths are now resolved against the workspace root before containment checks, and common mutating forms of otherwise read-only-looking commands (shell separators, write/exec flags, mutating Git forms, and `npm audit --fix`) are blocked before plan approval.
+
 ## 1.2.0 — 2026-05-28
 
 ### Plan mode is now enabled

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -46,6 +46,20 @@ function canonical(p: string): { norm: string; windows: boolean } {
   return { norm: windows ? s.toLowerCase() : s, windows };
 }
 
+function isAbsolutePath(p: string): boolean {
+  const s = String(p || "").trim();
+  return /^[\\/]{2}\?[\\/]/.test(s) || /^[a-zA-Z]:[\\/]/.test(s) ||
+    s.startsWith("/") || s.startsWith("\\");
+}
+
+function canonicalTarget(target: string, root: string): { norm: string; windows: boolean } {
+  if (isAbsolutePath(target)) return canonical(target);
+  const r = canonical(root);
+  const t = canonical(target);
+  const norm = nodePath.posix.normalize(`${r.norm}/${t.norm}`);
+  return { norm: r.windows ? norm.toLowerCase() : norm, windows: r.windows };
+}
+
 /**
  * True if `target` resolves to `root` itself or somewhere beneath it. Used to
  * decide whether a write lands in the user's workspace (block) or outside it
@@ -53,7 +67,7 @@ function canonical(p: string): { norm: string; windows: boolean } {
  */
 export function isInsideWorkspace(target: string, root: string): boolean {
   if (!target || !root) return false;
-  const t = canonical(target).norm;
+  const t = canonicalTarget(target, root).norm;
   const r = canonical(root).norm;
   if (r === "/" ) return t === "/" || t.startsWith("/");
   return t === r || t.startsWith(r + "/");
@@ -73,15 +87,14 @@ export function isMutatingKind(kind: string | undefined): boolean {
 // allowed only when every pipeline stage is itself read-only. Script-block
 // braces `{ }` are blocked because an otherwise-safe cmdlet can host arbitrary
 // code in one (e.g. `Select-Object @{e={ Remove-Item x }}`).
-const UNSAFE_SHELL = /[>;`{}]|\$\(|&&|\|\||(^|\s)&(\s|$)|<\(/;
+const UNSAFE_SHELL = /[>&;`{}\r\n]|\$\(|\|\||<\(/;
 
 const READONLY_HEADS = new Set([
   // POSIX
   "ls", "dir", "pwd", "cd", "echo", "cat", "type", "head", "tail", "less", "more",
   "grep", "rg", "ag", "ack", "find", "fd", "tree", "wc", "stat", "file", "which",
   "where", "whereis", "basename", "dirname", "realpath", "readlink", "du", "df",
-  "env", "printenv", "date", "whoami", "hostname", "uname", "sort", "uniq", "cut",
-  "awk", "sed", // sed/awk are read-only without -i / redirection (blocked above)
+  "printenv", "date", "whoami", "hostname", "uname", "sort", "uniq", "cut",
   // PowerShell read-only cmdlets + aliases. Inspection/formatting only — anything
   // that writes (out-file, set-content, tee-object, export-*) or executes
   // (foreach-object, where-object, invoke-expression/iex, invoke-command, start-process)
@@ -94,32 +107,111 @@ const READONLY_HEADS = new Set([
 ]);
 
 const GIT_READONLY = new Set([
-  "status", "diff", "log", "show", "branch", "remote", "ls-files", "ls-tree",
-  "rev-parse", "blame", "describe", "shortlog", "config", "cat-file", "name-rev",
-  "whatchanged", "reflog", "tag", // bare `git tag` lists; `git tag <name>` is rare in planning and harmless to block via fallthrough? we allow list-only below
+  "status", "diff", "log", "show", "ls-files", "ls-tree",
+  "rev-parse", "blame", "describe", "shortlog", "cat-file", "name-rev",
+  "whatchanged",
 ]);
 
 const PKG_READONLY = new Set(["ls", "list", "view", "info", "outdated", "why", "show", "audit"]);
+
+const GIT_BRANCH_READONLY_FLAGS = new Set([
+  "-a", "--all", "-r", "--remotes", "-v", "-vv", "--verbose", "--list",
+  "--show-current", "--merged", "--no-merged", "--contains", "--no-contains",
+  "--points-at", "--color", "--no-color", "--column", "--no-column",
+]);
+const GIT_BRANCH_READONLY_PREFIXES = ["--format=", "--sort=", "--color=", "--column="];
+
+const GIT_TAG_READONLY_FLAGS = new Set([
+  "-l", "--list", "-n", "--contains", "--no-contains", "--points-at",
+  "--merged", "--no-merged", "--color", "--no-color", "--column", "--no-column",
+]);
+const GIT_TAG_READONLY_PREFIXES = ["-n", "--format=", "--sort=", "--color=", "--column="];
+
+const GIT_WRITE_OUTPUT_OPTIONS = [
+  "--output=", "--output-directory=",
+];
+
+function hasToken(tokens: string[], ...blocked: string[]): boolean {
+  return tokens.some((t) => blocked.includes(t));
+}
+
+function hasTokenPrefix(tokens: string[], ...prefixes: string[]): boolean {
+  return tokens.some((t) => prefixes.some((p) => t.startsWith(p)));
+}
+
+function hasGitWriteOption(tokens: string[]): boolean {
+  return hasToken(tokens, "--output", "--output-directory", "--ext-diff") ||
+    hasTokenPrefix(tokens, ...GIT_WRITE_OUTPUT_OPTIONS);
+}
+
+function allReadOnlyOptionTokens(tokens: string[], exact: Set<string>, prefixes: string[]): boolean {
+  return tokens.every((t) => exact.has(t) || prefixes.some((p) => t.startsWith(p)));
+}
+
+function hasSedInPlace(tokens: string[]): boolean {
+  return tokens.some((t) => /^-[a-z]*i([a-z]|\b)/i.test(t) || t.startsWith("--in-place"));
+}
+
+function hasOutputOption(tokens: string[]): boolean {
+  return hasToken(tokens, "-o", "--output") || hasTokenPrefix(tokens, "--output=");
+}
+
+function isReadOnlyGit(tokens: string[]): boolean {
+  const sub = (tokens[1] || "").toLowerCase();
+  const args = tokens.slice(2).map((t) => t.toLowerCase());
+  if (hasGitWriteOption(args)) return false;
+  if (sub === "tag") return args.length === 0 ||
+    allReadOnlyOptionTokens(args, GIT_TAG_READONLY_FLAGS, GIT_TAG_READONLY_PREFIXES);
+  if (sub === "branch") return args.length === 0 ||
+    allReadOnlyOptionTokens(args, GIT_BRANCH_READONLY_FLAGS, GIT_BRANCH_READONLY_PREFIXES);
+  if (sub === "remote") {
+    if (args.length === 0 || allReadOnlyOptionTokens(args, new Set(["-v", "--verbose"]), [])) return true;
+    const action = args.find((a) => !a.startsWith("-"));
+    return action === "show" || action === "get-url";
+  }
+  if (sub === "reflog") {
+    if (args.length === 0) return true;
+    const action = args.find((a) => !a.startsWith("-")) || "show";
+    return action === "show";
+  }
+  if (sub === "config") {
+    if (args.length === 0) return false;
+    if (args.length === 1 && !args[0].startsWith("-")) return true;
+    return hasToken(args, "-l", "--list") ||
+      hasTokenPrefix(args, "--get", "--get-regexp", "--show-origin", "--show-scope");
+  }
+  return GIT_READONLY.has(sub);
+}
+
+function isReadOnlyPackageCommand(tokens: string[]): boolean {
+  const sub = (tokens[1] || "").toLowerCase();
+  const args = tokens.slice(2).map((t) => t.toLowerCase());
+  if (!PKG_READONLY.has(sub)) return false;
+  if (sub === "audit" && (hasToken(args, "fix") || hasTokenPrefix(args, "--fix"))) return false;
+  return true;
+}
 
 /** One pipeline stage: read-only iff its head token is a known read-only program. */
 function isReadOnlyStage(stage: string): boolean {
   const tokens = stage.trim().split(/\s+/);
   if (!tokens[0]) return false;
   const head = tokens[0].toLowerCase().replace(/\.(exe|cmd|bat)$/i, "");
+  const lowerTokens = tokens.map((t) => t.toLowerCase());
 
   if (head === "git") {
-    const sub = (tokens[1] || "").toLowerCase();
-    if (sub === "tag") return tokens.length === 2; // bare `git tag` lists; with args it may create
-    return GIT_READONLY.has(sub);
+    return isReadOnlyGit(lowerTokens);
   }
   if (head === "npm" || head === "pnpm" || head === "yarn" || head === "bun") {
-    const sub = (tokens[1] || "").toLowerCase();
-    return PKG_READONLY.has(sub);
+    return isReadOnlyPackageCommand(lowerTokens);
   }
   if (head === "node" || head === "python" || head === "python3" || head === "deno") {
     // Only allow trivially read-only invocations like `node --version`.
     return tokens.length >= 2 && /^(-v|--version|--help|-h)$/.test(tokens[1]);
   }
+  if (head === "sed" && hasSedInPlace(lowerTokens.slice(1))) return false;
+  if (head === "find" && hasToken(lowerTokens.slice(1), "-delete", "-exec", "-execdir", "-ok", "-okdir", "-fprint", "-fprint0", "-fprintf", "-fls")) return false;
+  if (head === "fd" && hasToken(lowerTokens.slice(1), "-x", "--exec", "--exec-batch")) return false;
+  if ((head === "sort" || head === "tree") && hasOutputOption(lowerTokens.slice(1))) return false;
   return READONLY_HEADS.has(head);
 }
 

--- a/test/acp-integration.test.ts
+++ b/test/acp-integration.test.ts
@@ -70,7 +70,8 @@ describe("ACP integration (real subprocess, fake CLI)", () => {
     workspace = fs.mkdtempSync(path.join(os.tmpdir(), "grok-int-ws-"));
     planHome = fs.mkdtempSync(path.join(os.tmpdir(), "grok-int-plan-"));
     const planPath = path.join(planHome, ".grok", "sessions", "cwd-x", "sess-y", "plan.md");
-    stderr = [];
+    const currentStderr: string[] = [];
+    stderr = currentStderr;
 
     client = new AcpClient({
       cliPath: fixtureCli(),
@@ -82,15 +83,16 @@ describe("ACP integration (real subprocess, fake CLI)", () => {
       },
       log: () => {},
     });
-    client.on("stderr", (t: string) => stderr.push(t));
+    client.on("stderr", (t: string) => currentStderr.push(t));
 
     // Wire up minimal fs/terminal handlers. Real fs writes for plan.md so we
     // can verify content lands on disk; in-memory terminal handler so we can
     // detect "was it called or blocked".
     client.fsRead = async (p) => fs.readFileSync(p, "utf8");
     client.fsWrite = async (p, content) => {
-      fs.mkdirSync(path.dirname(p), { recursive: true });
-      fs.writeFileSync(p, content, "utf8");
+      const target = path.isAbsolute(p) ? p : path.join(workspace, p);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content, "utf8");
     };
     let terminalCalls = 0;
     (client as any).terminal = {
@@ -158,6 +160,19 @@ describe("ACP integration (real subprocess, fake CLI)", () => {
     expect(fs.existsSync(path.join(workspace, "file.ts"))).toBe(false);
   });
 
+  it("gate: planActive=true blocks relative fs/write_text_file paths inside the workspace", async () => {
+    client.planActive = true;
+    const blocked = collect<{ kind: string; target: string }>(client, "mutationBlocked");
+
+    await client.prompt("SCENARIO_RELATIVE_WORKSPACE_WRITE");
+
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0].kind).toBe("write");
+    expect(blocked[0].target).toBe("relative-file.ts");
+    expect(stderr.join("")).toMatch(/WRITE_RESPONSE.*"error"/);
+    expect(fs.existsSync(path.join(workspace, "relative-file.ts"))).toBe(false);
+  });
+
   it("gate: planActive=false allows fs/write_text_file inside the workspace", async () => {
     client.planActive = false;
     const blocked = collect<unknown>(client, "mutationBlocked");
@@ -178,6 +193,18 @@ describe("ACP integration (real subprocess, fake CLI)", () => {
     expect(blocked[0].kind).toBe("terminal");
     expect(blocked[0].target).toContain("rm");
     expect((client as any).__terminalCalls()).toBe(0); // handler was never reached
+  });
+
+  it("gate: planActive=true blocks terminal/create with mutating args on an otherwise read-only head", async () => {
+    client.planActive = true;
+    const blocked = collect<{ kind: string; target: string }>(client, "mutationBlocked");
+
+    await client.prompt("SCENARIO_MUTATING_READONLY_HEAD_TERMINAL");
+
+    expect(blocked).toHaveLength(1);
+    expect(blocked[0].kind).toBe("terminal");
+    expect(blocked[0].target).toContain("sed");
+    expect((client as any).__terminalCalls()).toBe(0);
   });
 
   it("gate: planActive=true allows terminal/create with a read-only command (ls)", async () => {

--- a/test/fixtures/fake-grok-acp.cjs
+++ b/test/fixtures/fake-grok-acp.cjs
@@ -28,12 +28,22 @@ function notify(method, params) { send({ jsonrpc: "2.0", method, params }); }
 function callClient(method, params) {
   const id = nextId++;
   send({ jsonrpc: "2.0", id, method, params });
-  return new Promise((resolve) => { pendingReplies.set(id, resolve); });
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      pendingReplies.delete(id);
+      resolve({ error: { code: -32099, message: `Timed out waiting for ${method}` } });
+    }, 2000);
+    pendingReplies.set(id, (reply) => {
+      clearTimeout(timer);
+      resolve(reply);
+    });
+  });
 }
 
 const SESSION_ID = "fake-session-1";
 const PLAN_PATH = process.env.FAKE_PLAN_PATH || "/tmp/fake-grok-home/.grok/sessions/cwd-x/sess-y/plan.md";
 const WORKSPACE_FILE = (process.env.FAKE_WORKSPACE_ROOT || "/tmp/fake-workspace") + "/file.ts";
+const RELATIVE_WORKSPACE_FILE = "relative-file.ts";
 
 rl.on("line", async (line) => {
   if (!line.trim()) return;
@@ -104,8 +114,22 @@ async function runScenario(promptId, text) {
       return;
     }
 
+    if (text.includes("SCENARIO_RELATIVE_WORKSPACE_WRITE")) {
+      const writeResp = await callClient("fs/write_text_file", { sessionId: SESSION_ID, path: RELATIVE_WORKSPACE_FILE, content: "// relative file" });
+      process.stderr.write(`WRITE_RESPONSE: ${JSON.stringify(writeResp)}\n`);
+      respondOk(promptId, { stopReason: "end_turn", _meta: { totalTokens: 50 } });
+      return;
+    }
+
     if (text.includes("SCENARIO_MUTATING_TERMINAL")) {
       const termResp = await callClient("terminal/create", { sessionId: SESSION_ID, command: "rm -rf /tmp/foo" });
+      process.stderr.write(`TERMINAL_RESPONSE: ${JSON.stringify(termResp)}\n`);
+      respondOk(promptId, { stopReason: "end_turn", _meta: { totalTokens: 50 } });
+      return;
+    }
+
+    if (text.includes("SCENARIO_MUTATING_READONLY_HEAD_TERMINAL")) {
+      const termResp = await callClient("terminal/create", { sessionId: SESSION_ID, command: "sed -i s/a/b/ file.ts" });
       process.stderr.write(`TERMINAL_RESPONSE: ${JSON.stringify(termResp)}\n`);
       respondOk(promptId, { stopReason: "end_turn", _meta: { totalTokens: 50 } });
       return;

--- a/test/plan-gate.test.ts
+++ b/test/plan-gate.test.ts
@@ -43,6 +43,10 @@ describe("isInsideWorkspace", () => {
     expect(isInsideWorkspace("C:\\proj-other\\a.ts", "C:\\proj")).toBe(false);
   });
 
+  it("does not treat an absolute UNC path as workspace-relative", () => {
+    expect(isInsideWorkspace("\\\\server\\share\\file.ts", "C:\\proj")).toBe(false);
+  });
+
   it("resolves .. traversal that escapes the workspace as outside", () => {
     expect(isInsideWorkspace("/work/../etc/passwd", "/work")).toBe(false);
     expect(isInsideWorkspace("/work/sub/../keep.ts", "/work")).toBe(true);
@@ -78,13 +82,19 @@ describe("shouldBlockWrite", () => {
   it("blocks a nested workspace file while planning", () => {
     expect(shouldBlockWrite("/home/u/proj/src/deep/nested/x.ts", active("/home/u/proj"))).toBe(true);
   });
+
+  it("blocks a relative workspace write while planning", () => {
+    expect(shouldBlockWrite("src/file.ts", active("/home/u/proj"))).toBe(true);
+  });
 });
 
 describe("isReadOnlyCommand", () => {
   it("allows common read-only exploration commands", () => {
     for (const c of ["ls -la", "git status", "git diff HEAD~1", "git log --oneline",
                      "grep -rn foo src", "rg pattern", "cat package.json", "find . -name *.ts",
-                     "npm ls", "pnpm outdated", "node --version", "git rev-parse HEAD"]) {
+                     "npm ls", "pnpm outdated", "node --version", "git rev-parse HEAD",
+                     "git branch -vv", "git remote -v", "git remote show origin",
+                     "git config --get user.name", "git tag --list", "git reflog show"]) {
       expect(isReadOnlyCommand(c), c).toBe(true);
     }
   });
@@ -97,11 +107,34 @@ describe("isReadOnlyCommand", () => {
     }
   });
 
+  it("blocks mutating forms of otherwise read-only command heads", () => {
+    for (const c of ["sed -i s/a/b/ src/file.ts", "sed -Ei s/a/b/ src/file.ts",
+                     "sed --in-place=.bak s/a/b/ src/file.ts",
+                     "find . -delete", "find . -fprint out.txt", "find . -fprintf out.txt %p",
+                     "fd -x touch src/pwned", "fd --exec-batch touch src/pwned",
+                     "sort -o out.txt input.txt", "tree -o tree.txt",
+                     "git diff --output=patch.diff", "git diff --ext-diff",
+                     "git config user.name x", "git branch newbranch",
+                     "git branch --unset-upstream", "git remote add origin example",
+                     "git remote set-url origin example", "git reflog expire --expire=now --all",
+                     "git tag -d v1.0.0", "npm audit --fix"]) {
+      expect(isReadOnlyCommand(c), c).toBe(false);
+    }
+  });
+
   it("blocks read-only heads when chaining/redirection is present", () => {
     expect(isReadOnlyCommand("git diff && rm -rf x")).toBe(false);
+    expect(isReadOnlyCommand("echo ok&touch src/pwned")).toBe(false);
+    expect(isReadOnlyCommand("ls\nrm -rf src")).toBe(false);
     expect(isReadOnlyCommand("cat secrets > out.txt")).toBe(false);
     expect(isReadOnlyCommand("ls | xargs rm")).toBe(false);
     expect(isReadOnlyCommand("echo $(rm x)")).toBe(false);
+  });
+
+  it("blocks read-only-looking commands that can execute arbitrary commands", () => {
+    expect(isReadOnlyCommand("env touch src/pwned")).toBe(false);
+    expect(isReadOnlyCommand("awk 'BEGIN { system(\"touch src/pwned\") }'")).toBe(false);
+    expect(isReadOnlyCommand("sed '1e touch src/pwned' file.ts")).toBe(false);
   });
 
   it("allows read-only PowerShell pipelines (the common plan-mode listing)", () => {


### PR DESCRIPTION
Fixes #5.

## Summary

This keeps the existing Plan mode design intact, but tightens the client-side gate at the two existing enforcement points:

- Resolve relative `fs/write_text_file` paths against the workspace root before deciding whether Plan mode should block the write.
- Continue allowing/snooping Grok's own `.grok/sessions/.../plan.md` writes outside the workspace.
- Treat common mutating forms of otherwise read-only-looking terminal commands as unsafe before plan approval, including shell separators/newlines, command-executing heads like `env`/`awk`/`sed`, write/exec flags on `find`/`fd`/`sort`/`tree`, mutating Git forms, and `npm audit --fix`.
- Add pure plan-gate coverage plus fake-ACP integration tests for relative writes and mutating terminal commands.
- Make the fake ACP fixture fail faster when a server-to-client request is not answered.

## Verification

- `npm ci`
- `npm audit --audit-level=high` passes; npm still reports the repo's existing moderate Vitest/Vite/esbuild dev-dependency advisories, whose available fix is a breaking Vitest upgrade.
- `npm run compile`
- `npm test` (`189` tests passing)
- `npm run package`
- `npm test -- --run test/plan-gate.test.ts test/acp-integration.test.ts` (`44` targeted tests passing after the final changelog wording change)
- `git diff --check`

## Notes

This intentionally stays conservative rather than introducing a general shell parser. Anything outside the explicit read-only allowlist remains blocked while Plan mode is active.
