### PR TITLE
Open plan review cards as Markdown snapshots

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -1001,6 +1001,23 @@ body.dragging { outline: 2px dashed var(--vscode-focusBorder); outline-offset: -
   text-decoration: underline;
   text-align: left;
 }
+.plan-tools {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: -2px;
+}
+.plan-file-link {
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+.plan-file-link code {
+  background: transparent;
+  padding: 0;
+}
+.plan-file-link:hover {
+  background: var(--vscode-list-hoverBackground);
+}
 .card .plan-body {
   margin: 0;
   font-size: 12px;

--- a/media/chat.js
+++ b/media/chat.js
@@ -1234,7 +1234,7 @@
     if (!state.planHistoryQueue.length) return;
     state.planHistoryQueue = state.planHistoryQueue.filter((p) => {
       if (typeof p.afterUserMessage === "number" && p.afterUserMessage <= cutoff) {
-        addPlanHistoryCard(p.text, p.verdict);
+        addPlanHistoryCard(p.text, p.verdict, p.planPath, p.planName);
         return false;
       }
       return true;
@@ -1243,7 +1243,7 @@
 
   function flushPlanHistory() {
     if (!state.planHistoryQueue.length) return;
-    for (const p of state.planHistoryQueue) addPlanHistoryCard(p.text, p.verdict);
+    for (const p of state.planHistoryQueue) addPlanHistoryCard(p.text, p.verdict, p.planPath, p.planName);
     state.planHistoryQueue = [];
   }
 
@@ -1338,6 +1338,25 @@
     abandoned: "Cancelled",
   };
 
+  function pathBaseName(p) {
+    return String(p || "").split(/[\\/]/).filter(Boolean).pop() || "plan.md";
+  }
+
+  function addPlanFileLink(el, planPath, planName) {
+    if (!planPath) return;
+    const planTools = document.createElement("div");
+    planTools.className = "plan-tools";
+    const link = document.createElement("a");
+    link.className = "file-ref-link plan-file-link";
+    link.href = planPath;
+    link.title = planPath;
+    const code = document.createElement("code");
+    code.textContent = planName || pathBaseName(planPath);
+    link.appendChild(code);
+    planTools.appendChild(link);
+    el.appendChild(planTools);
+  }
+
   function addPlanCard(req) {
     clearWelcome();
     // Finalize any in-flight Thinking / agent / tool group so it doesn't sit
@@ -1356,9 +1375,12 @@
     sub.textContent = "Nothing has been written yet. Approve, reject with feedback, or cancel to leave plan mode.";
     el.appendChild(sub);
 
+    const planText = req.plan || "";
+    addPlanFileLink(el, req.planPath, req.planName);
+
     const body = document.createElement("div");
     body.className = "plan-body";
-    body.innerHTML = req.plan ? renderMarkdown(req.plan) : "(empty plan)";
+    body.innerHTML = planText ? renderMarkdown(planText) : "(empty plan)";
     el.appendChild(body);
 
     const feedback = document.createElement("textarea");
@@ -1408,7 +1430,7 @@
   // is long gone, so there's nothing to respond to — we just show the plan text
   // grok wrote during that session, recovered from ~/.grok/sessions/.../plan.md,
   // and the verdict the user gave it (persisted in globalState).
-  function addPlanHistoryCard(text, verdict) {
+  function addPlanHistoryCard(text, verdict, planPath, planName) {
     clearWelcome();
     const el = document.createElement("div");
     el.className = "card plan plan-history";
@@ -1424,6 +1446,8 @@
       ? `Restored from the previous session — you ${verdictLabel.toLowerCase()} this plan.`
       : "Restored from the previous session.";
     el.appendChild(sub);
+
+    addPlanFileLink(el, planPath, planName);
 
     const body = document.createElement("div");
     body.className = "plan-body";
@@ -1686,7 +1710,7 @@
         addPlanCard(msg.req);
         break;
       case "planHistory":
-        addPlanHistoryCard(msg.text, msg.verdict);
+        addPlanHistoryCard(msg.text, msg.verdict, msg.planPath, msg.planName);
         break;
       case "planNotice":
         addPlanNotice(msg.text);
@@ -1876,7 +1900,7 @@
     const href = a.getAttribute("href") || "";
     if (/^https?:\/\//i.test(href)) {
       vscode.postMessage({ type: "openUrl", url: href });
-    } else if (!/^[a-z][a-z0-9+.-]*:/i.test(href)) {
+    } else if (/^[a-zA-Z]:[\\/]/.test(href) || href.startsWith("\\\\") || !/^[a-z][a-z0-9+.-]*:/i.test(href)) {
       vscode.postMessage({ type: "openFile", path: href });
     }
   });

--- a/src/plan-review.ts
+++ b/src/plan-review.ts
@@ -1,0 +1,18 @@
+export function planReviewFileBaseName(plan: string): string {
+  const firstLine = String(plan || "")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^#+\s*/, "").trim())
+    .find((line) => line && !/^status\s*:/i.test(line));
+  if (!firstLine) return "plan";
+  const namedPrefix = firstLine.match(/^([a-z0-9][a-z0-9._ -]{0,60})\s*:/i);
+  return sanitizePlanReviewFilePart(namedPrefix ? namedPrefix[1] : firstLine).slice(0, 80) || "plan";
+}
+
+export function sanitizePlanReviewFilePart(value: string): string {
+  return String(value || "")
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\w.-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-") || "plan";
+}

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -15,6 +15,7 @@ import {
 import { buildPrompt } from "./prompt-builder";
 import { pickRejectOption, shouldRejectPermission } from "./plan-gate";
 import { appendPlanEntry, decideRestoreState } from "./plan-restore";
+import { planReviewFileBaseName, sanitizePlanReviewFilePart } from "./plan-review";
 import { GROK_PRIMER } from "./grok-primer";
 import {
   SessionListEntry,
@@ -673,12 +674,7 @@ See design doc for the full state machine diagram.`;
     });
     client.on("exitPlanRequest", (req: ExitPlanRequest) => {
       if (gen !== this.sessionGen) return;
-      const plan = req.plan || this.lastPlanText;
-      // Hold onto the plan text until the user picks a verdict so persistPlanVerdict
-      // can save it. Cleared (via resolved/pending) so the next plan starts fresh.
-      this.pendingPlanText = plan;
-      this.lastPlanText = "";
-      this.post({ type: "exitPlanRequest", req: { ...req, plan } });
+      void this.postExitPlanRequest(req, gen);
     });
     client.on("exit", (code) => {
       if (gen !== this.sessionGen) return; // suppress exit events from disposed/replaced clients
@@ -697,7 +693,7 @@ See design doc for the full state machine diagram.`;
         const overrides = this.context.globalState.get<SessionMetaOverrides>(SESSION_META_KEY, {});
         const saved = overrides[resumeId]?.plans ?? [];
         if (saved.length > 0) {
-          this.post({ type: "planHistoryQueue", plans: saved });
+          this.post({ type: "planHistoryQueue", plans: await this.withPlanReviewPaths(saved, resumeId) });
           this.lastPlanText = saved[saved.length - 1].text;
         } else {
           // Legacy session (no per-plan persistence): fall back to the on-disk
@@ -706,7 +702,21 @@ See design doc for the full state machine diagram.`;
           if (fs.existsSync(planPath)) {
             try {
               const planText = fs.readFileSync(planPath, "utf8");
-              this.post({ type: "planHistoryQueue", plans: [{ text: planText, verdict: undefined as any }] });
+              let snapshot: { path: string; name: string } | undefined;
+              try {
+                snapshot = await this.createPlanReviewSnapshot(planText, resumeId);
+              } catch (e) {
+                this.output.appendLine(`[plan-review] ${(e as Error).message}`);
+              }
+              this.post({
+                type: "planHistoryQueue",
+                plans: [{
+                  text: planText,
+                  verdict: undefined as any,
+                  planPath: snapshot?.path,
+                  planName: snapshot?.name,
+                }],
+              });
               this.lastPlanText = planText;
             } catch (e) {
               this.output.appendLine(`[plan-restore] ${(e as Error).message}`);
@@ -1063,6 +1073,69 @@ See design doc for the full state machine diagram.`;
     );
     // (tmp/after refs intentionally unused — we use openTextDocument's auto URIs)
     void tmp; void after;
+  }
+
+  private async postExitPlanRequest(req: ExitPlanRequest, gen: number): Promise<void> {
+    const plan = req.plan || this.lastPlanText;
+    let snapshot: { path: string; name: string } | undefined;
+    try {
+      snapshot = await this.createPlanReviewSnapshot(plan);
+    } catch (e) {
+      this.output.appendLine(`[plan-review] ${(e as Error).message}`);
+    }
+    if (gen !== this.sessionGen) return;
+    // Hold onto the plan text until the user picks a verdict so persistPlanVerdict
+    // can save it. Cleared (via resolved/pending) so the next plan starts fresh.
+    this.pendingPlanText = plan;
+    this.lastPlanText = "";
+    this.post({
+      type: "exitPlanRequest",
+      req: { ...req, plan, planPath: snapshot?.path, planName: snapshot?.name },
+    });
+  }
+
+  private async withPlanReviewPaths<T extends { text: string }>(
+    plans: T[],
+    sessionId?: string,
+  ): Promise<Array<T & { planPath?: string; planName?: string }>> {
+    const out: Array<T & { planPath?: string; planName?: string }> = [];
+    for (const plan of plans) {
+      try {
+        const snapshot = await this.createPlanReviewSnapshot(plan.text, sessionId);
+        out.push({ ...plan, planPath: snapshot.path, planName: snapshot.name });
+      } catch (e) {
+        this.output.appendLine(`[plan-review] ${(e as Error).message}`);
+        out.push(plan);
+      }
+    }
+    return out;
+  }
+
+  private async createPlanReviewSnapshot(plan: string, sessionId?: string): Promise<{ path: string; name: string }> {
+    const content = plan && plan.trim() ? plan : "(empty plan)\n";
+    const sessionPart = sanitizePlanReviewFilePart(
+      sessionId ?? this.activeSessionId ?? this.client?.sessionId ?? "session",
+    ).slice(0, 80);
+    const dir = vscode.Uri.joinPath(this.context.globalStorageUri, "plan-reviews", sessionPart);
+    await vscode.workspace.fs.createDirectory(dir);
+    const uri = await this.uniquePlanReviewUri(dir, `${planReviewFileBaseName(content)}.md`);
+    await vscode.workspace.fs.writeFile(uri, Buffer.from(content, "utf8"));
+    return { path: uri.fsPath, name: path.basename(uri.fsPath) };
+  }
+
+  private async uniquePlanReviewUri(dir: vscode.Uri, fileName: string): Promise<vscode.Uri> {
+    const ext = path.extname(fileName);
+    const stem = path.basename(fileName, ext);
+    for (let i = 0; i < 100; i += 1) {
+      const suffix = i === 0 ? "" : `-${i + 1}`;
+      const uri = vscode.Uri.joinPath(dir, `${stem}${suffix}${ext}`);
+      try {
+        await vscode.workspace.fs.stat(uri);
+      } catch {
+        return uri;
+      }
+    }
+    return vscode.Uri.joinPath(dir, `${stem}-${Date.now()}${ext}`);
   }
 
   private addDroppedFile(absPath: string, shiftHeld: boolean): void {

--- a/test/plan-card.dom.test.ts
+++ b/test/plan-card.dom.test.ts
@@ -19,14 +19,48 @@ import { bootWebview, dispatch, click } from "./webview-harness";
 describe("plan card (real chat.js in a DOM)", () => {
   it("renders a plan card with body, feedback textarea, and three action buttons", () => {
     const { window, doc } = bootWebview();
-    dispatch(window, { type: "exitPlanRequest", req: { id: 7, plan: "1. add subtract()\n2. add test" } });
+    dispatch(window, {
+      type: "exitPlanRequest",
+      req: {
+        id: 7,
+        plan: "1. add subtract()\n2. add test",
+        planPath: "/tmp/grok/plan2.md",
+        planName: "plan2.md",
+      },
+    });
 
     const card = doc.querySelector(".card.plan");
     expect(card).not.toBeNull();
     expect(card!.querySelector(".plan-body")!.textContent).toContain("add subtract()");
+    expect(card!.querySelector(".plan-file-link code")!.textContent).toBe("plan2.md");
     expect(card!.querySelector("textarea.plan-feedback")).not.toBeNull();
     const labels = [...card!.querySelectorAll(".card-actions button")].map((b) => b.textContent);
     expect(labels).toEqual(["Approve & implement", "Reject", "Cancel"]);
+  });
+
+  it("opens the live plan link without resolving the approval card", () => {
+    const plan = "# Plan\n\n- inspect\n- edit\n\n```ts\nconst x = 1;\n```";
+    const { window, posted, doc } = bootWebview();
+    dispatch(window, {
+      type: "exitPlanRequest",
+      req: { id: 8, plan, planPath: "/tmp/grok/plan2.md", planName: "plan2.md" },
+    });
+
+    const card = doc.querySelector(".card.plan")!;
+    const feedback = card.querySelector("textarea.plan-feedback") as HTMLTextAreaElement;
+    feedback.value = "  keep this comment  ";
+    const link = card.querySelector(".plan-file-link") as HTMLAnchorElement;
+    expect(link.title).toBe("/tmp/grok/plan2.md");
+    click(window, link);
+
+    expect(posted).toEqual([{ type: "openFile", path: "/tmp/grok/plan2.md" }]);
+    expect(card.classList.contains("resolved")).toBe(false);
+    expect(card.querySelector(".plan-verdict-label")).toBeNull();
+    const approve = [...card.querySelectorAll(".card-actions button")]
+      .find((b) => b.textContent === "Approve & implement") as HTMLButtonElement;
+    expect(approve.disabled).toBe(false);
+    expect(feedback.disabled).toBe(false);
+    expect(feedback.value).toBe("  keep this comment  ");
   });
 
   it("'Reject' with empty feedback sends verdict:rejected and NO comment key", () => {
@@ -138,15 +172,38 @@ describe("plan card (real chat.js in a DOM)", () => {
 
   it("renders a read-only plan-history card with the persisted verdict label", () => {
     const { window, doc } = bootWebview();
-    dispatch(window, { type: "planHistory", text: "# Restored plan\n- step 1", verdict: "rejected" });
+    dispatch(window, {
+      type: "planHistory",
+      text: "# Restored plan\n- step 1",
+      verdict: "rejected",
+      planPath: "/tmp/grok/restored-plan.md",
+      planName: "restored-plan.md",
+    });
 
     const cards = doc.querySelectorAll(".card.plan.plan-history");
     expect(cards).toHaveLength(1);
     const card = cards[0];
     expect(card.querySelector(".plan-body")!.textContent).toContain("step 1");
+    expect(card.querySelector(".plan-file-link code")!.textContent).toBe("restored-plan.md");
     expect(card.querySelector(".plan-verdict-label")!.textContent).toBe("Rejected");
     expect(card.querySelector(".card-actions")).toBeNull();
     expect(card.querySelector("textarea")).toBeNull();
+  });
+
+  it("opens a restored plan link", () => {
+    const { window, posted, doc } = bootWebview();
+    dispatch(window, {
+      type: "planHistory",
+      text: "# Restored plan\n- step 1",
+      verdict: "approved",
+      planPath: "/tmp/grok/restored-plan.md",
+      planName: "restored-plan.md",
+    });
+
+    const link = doc.querySelector(".card.plan.plan-history .plan-file-link") as HTMLAnchorElement;
+    click(window, link);
+
+    expect(posted).toEqual([{ type: "openFile", path: "/tmp/grok/restored-plan.md" }]);
   });
 
   it("renders a plan-notice for planNotice and the blocked-command/-write variants", () => {

--- a/test/plan-history-restore.dom.test.ts
+++ b/test/plan-history-restore.dom.test.ts
@@ -17,7 +17,7 @@
 // content lost", "stuck in plan mode after Cancel restore" — would all show up
 // here if regressed.
 import { describe, it, expect } from "vitest";
-import { bootWebview, dispatch } from "./webview-harness";
+import { bootWebview, dispatch, click } from "./webview-harness";
 
 // All visible message children in DOM order, mapped to a compact label so
 // assertions read like a transcript instead of a DOM dump.
@@ -171,6 +171,40 @@ describe("plan-history queue (restore-flow rendering)", () => {
       "plan[Rejected]: first attempt",
       "plan[Rejected]: second attempt",
       "user: u2",
+    ]);
+  });
+
+  it("queued plan-history cards open the matching plan file link", () => {
+    const { window, posted, doc } = bootWebview();
+    plays(window, [
+      { type: "planHistoryQueue", plans: [
+        {
+          text: "first restored plan",
+          verdict: "rejected",
+          afterUserMessage: 0,
+          planPath: "/tmp/grok/first-plan.md",
+          planName: "first-plan.md",
+        },
+        {
+          text: "second restored plan",
+          verdict: "abandoned",
+          afterUserMessage: 0,
+          planPath: "/tmp/grok/second-plan.md",
+          planName: "second-plan.md",
+        },
+      ]},
+      { type: "userMessage", text: "continue", chips: [] },
+    ]);
+
+    const cards = [...doc.querySelectorAll(".card.plan.plan-history")] as HTMLElement[];
+    expect(cards[0].querySelector(".plan-file-link code")!.textContent).toBe("first-plan.md");
+    expect(cards[1].querySelector(".plan-file-link code")!.textContent).toBe("second-plan.md");
+    click(window, cards[0].querySelector(".plan-file-link")!);
+    click(window, cards[1].querySelector(".plan-file-link")!);
+
+    expect(posted).toEqual([
+      { type: "openFile", path: "/tmp/grok/first-plan.md" },
+      { type: "openFile", path: "/tmp/grok/second-plan.md" },
     ]);
   });
 

--- a/test/plan-review.test.ts
+++ b/test/plan-review.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { planReviewFileBaseName, sanitizePlanReviewFilePart } from "../src/plan-review";
+
+describe("planReviewFileBaseName", () => {
+  it("uses an explicit plan name prefix as the file base", () => {
+    expect(planReviewFileBaseName("plan2: Simple Plan Example\n\n## Context")).toBe("plan2");
+  });
+
+  it("uses a markdown heading when no explicit prefix exists", () => {
+    expect(planReviewFileBaseName("# Refactor auth helper\n\nSteps...")).toBe("refactor-auth-helper");
+  });
+
+  it("skips status lines when picking a useful title", () => {
+    expect(planReviewFileBaseName("Status: Ready\n# Add tests")).toBe("add-tests");
+  });
+});
+
+describe("sanitizePlanReviewFilePart", () => {
+  it("creates a filesystem-friendly ascii slug", () => {
+    expect(sanitizePlanReviewFilePart("Plan: Review / Copy Path!")).toBe("plan-review-copy-path");
+  });
+
+  it("falls back to plan for empty values", () => {
+    expect(sanitizePlanReviewFilePart("   ")).toBe("plan");
+  });
+});


### PR DESCRIPTION
Fixes #7.

## Summary

This preserves the existing Plan mode design while making long plans easier to review in VS Code:

- create extension-owned Markdown snapshots for live plan-review cards
- create snapshots for restored plan-history cards
- show a file link on plan cards that opens the snapshot in a VS Code editor tab
- keep the plan card state unchanged when the link is opened: no verdict is sent, approval controls remain active, and typed feedback is preserved
- avoid reading or mutating Grok's own `.grok/sessions/.../plan.md` as the review target, since that file remains CLI-owned session state
- add DOM coverage for live/restored plan links plus pure coverage for snapshot filename generation

## Verification

- `git diff --check`
- `npm ci`
- `npm audit --audit-level=high`
- `npm run compile`
- `npm test` (191 tests)
- `npm run package`

## Notes

This does not change Plan mode enforcement, verdict handling, or Grok/ACP session ownership. It only adds a VS Code-native review surface for the plan text already shown in the sidebar.

`npm audit --audit-level=high` passes. npm reports existing moderate dev-dependency advisories in the Vitest/Vite/esbuild chain; fixing those requires a breaking Vitest upgrade and is intentionally left out of this scoped PR.
