### PR TITLE
Allow Grok plan.md writes when home is the workspace

### DIFF
--- a/src/acp.ts
+++ b/src/acp.ts
@@ -18,6 +18,7 @@ import {
   shouldBlockTerminal,
   shouldBlockWrite,
 } from "./plan-gate";
+import { resolveGrokHome } from "./sessions";
 
 export type EffortLevel = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
@@ -400,7 +401,11 @@ export class AcpClient extends EventEmitter {
         if (isPlanFileWrite(params.path)) {
           this.emit("planFileContent", params.content ?? "");
         }
-        if (shouldBlockWrite(params.path, { active: this.planActive, workspaceRoot: this.opts.cwd })) {
+        if (shouldBlockWrite(params.path, {
+          active: this.planActive,
+          workspaceRoot: this.opts.cwd,
+          grokHome: resolveGrokHome(this.opts.env ?? process.env),
+        })) {
           this.emit("mutationBlocked", { kind: "write", target: params.path });
           this.respondError(id, PLAN_BLOCKED_CODE, PLAN_BLOCKED_WRITE_MSG);
           return;

--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -63,7 +63,8 @@ function canonicalTarget(target: string, root: string): { norm: string; windows:
 /**
  * True if `target` resolves to `root` itself or somewhere beneath it. Used to
  * decide whether a write lands in the user's workspace (block) or outside it
- * (allow — e.g. grok's `~/.grok/.../plan.md`).
+ * (allow). Grok's own `~/.grok/.../plan.md` is handled separately because a
+ * user may open their home directory as the workspace root.
  */
 export function isInsideWorkspace(target: string, root: string): boolean {
   if (!target || !root) return false;
@@ -234,11 +235,14 @@ export function isReadOnlyCommand(command: string): boolean {
 export interface PlanGateContext {
   active: boolean;
   workspaceRoot: string;
+  grokHome?: string;
 }
 
 /** Should `fs/write_text_file` to `path` be refused right now? */
 export function shouldBlockWrite(path: string, ctx: PlanGateContext): boolean {
-  return ctx.active && isInsideWorkspace(path, ctx.workspaceRoot);
+  const isOwnPlanFile = isPlanFileWrite(path) &&
+    (!ctx.grokHome || isInsideWorkspace(path, ctx.grokHome));
+  return ctx.active && !isOwnPlanFile && isInsideWorkspace(path, ctx.workspaceRoot);
 }
 
 /** Should `terminal/create` of `command` be refused right now? */

--- a/test/plan-gate.test.ts
+++ b/test/plan-gate.test.ts
@@ -17,7 +17,7 @@ const WIN_WORKSPACE_WRITE = "\\\\?\\C:\\Users\\Dell\\AppData\\Local\\Temp\\grok-
 const WIN_PLAN_FILE =
   "\\\\?\\C:\\Users\\Dell\\.grok\\sessions\\C%3A%5CUsers%5CDell%5CAppData%5CLocal%5CTemp%5Cgrok-plan-exp-GyuZ1W\\019e6b7e\\plan.md";
 
-const active = (root: string): PlanGateContext => ({ active: true, workspaceRoot: root });
+const active = (root: string, grokHome?: string): PlanGateContext => ({ active: true, workspaceRoot: root, grokHome });
 const off = (root: string): PlanGateContext => ({ active: false, workspaceRoot: root });
 
 describe("isInsideWorkspace", () => {
@@ -64,7 +64,25 @@ describe("shouldBlockWrite", () => {
   });
 
   it("ALLOWS grok writing its own plan.md while planning (outside workspace)", () => {
-    expect(shouldBlockWrite(WIN_PLAN_FILE, active(WIN_ROOT))).toBe(false);
+    expect(shouldBlockWrite(WIN_PLAN_FILE, active(WIN_ROOT, "C:\\Users\\Dell\\.grok"))).toBe(false);
+  });
+
+  it("ALLOWS grok writing its own plan.md even when the home dir is the workspace", () => {
+    const posixHomePlan = "/home/u/.grok/sessions/%2Fhome%2Fu/019e7608/plan.md";
+    expect(isPlanFileWrite(posixHomePlan)).toBe(true);
+    expect(isInsideWorkspace(posixHomePlan, "/home/u")).toBe(true);
+    expect(shouldBlockWrite(posixHomePlan, active("/home/u", "/home/u/.grok"))).toBe(false);
+
+    expect(isPlanFileWrite(WIN_PLAN_FILE)).toBe(true);
+    expect(isInsideWorkspace(WIN_PLAN_FILE, "C:\\Users\\Dell")).toBe(true);
+    expect(shouldBlockWrite(WIN_PLAN_FILE, active("C:\\Users\\Dell", "C:\\Users\\Dell\\.grok"))).toBe(false);
+  });
+
+  it("does not treat an arbitrary project-local .grok/sessions plan file as grok's own plan.md", () => {
+    const projectPlan = "/home/u/proj/.grok/sessions/%2Fhome%2Fu%2Fproj/019e7608/plan.md";
+    expect(isPlanFileWrite(projectPlan)).toBe(true);
+    expect(isInsideWorkspace(projectPlan, "/home/u/proj")).toBe(true);
+    expect(shouldBlockWrite(projectPlan, active("/home/u/proj", "/home/u/.grok"))).toBe(true);
   });
 
   it("allows any write when the gate is off (normal Agent mode never blocks)", () => {


### PR DESCRIPTION
Fixes #10.

## Summary

Plan mode should allow and snoop Grok's own `.grok/sessions/.../plan.md` writes, but v1.2.2 can still block them when the VS Code workspace root is the user's home directory. In that layout, the plan file is both:

- recognized as Grok's plan file, and
- inside the workspace containment root

This updates the write gate so plan-file writes are exempted before workspace containment is applied, but only when the path is under the resolved Grok home (`~/.grok`). That keeps normal workspace writes blocked and avoids treating an arbitrary project-local `.grok/sessions/.../plan.md` as Grok's own session file.

## Verification

- Added a regression test covering both POSIX home workspace and Windows home workspace layouts.
- Added a guard test that a project-local `.grok/sessions/.../plan.md` remains blocked when it is not under the resolved Grok home.
- Verified the home-workspace regression test fails before the source fix.
- `npm test -- --run test/plan-gate.test.ts test/acp-integration.test.ts` (49 tests)
- `npm run compile`
- `git diff --check`
- `npm test` (223 tests)
- `npm run package`

## Local confirmation

After installing the patched VSIX locally, the exact observed path now evaluates correctly:

```js
isPlanFileWrite('/home/shugav/.grok/sessions/%2Fhome%2Fshugav/019e7608-.../plan.md') === true
isInsideWorkspace(..., '/home/shugav') === true
shouldBlockWrite(..., {
  active: true,
  workspaceRoot: '/home/shugav',
  grokHome: '/home/shugav/.grok'
}) === false
```

## Notes

This preserves the existing Plan mode design: normal workspace writes remain blocked while planning, but Grok's CLI-owned plan file remains allowed and snooped even when the user opens their home directory as the workspace.