### PR TITLE
Add support for Antigravity IDE in macOS install and uninstall scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - **The sign-in (and sign-out) terminal commands actually run now.** The onboarding button typed `"C:\…\grok.exe" /login` into the terminal — the wrong command (`login` is the CLI subcommand; `/login` only works inside the interactive TUI) *and* a PowerShell parser error (a quoted path followed by arguments needs the `&` call operator). Sign-in and sign-out now launch the grok binary directly as the terminal's own process, which behaves the same on PowerShell, cmd, and POSIX shells. README examples updated to `grok login` too. ([media/chat.js](media/chat.js), [src/sidebar.ts](src/sidebar.ts), [README.md](README.md))
+- **Session startup no longer crashes on invalid or missing models.** Catch and log errors if `setModel` fails on session creation or load (e.g. if a model is invalid or unsupported), falling back gracefully instead of exiting with an error. ([src/acp.ts](src/acp.ts))
+- **Added a warning for unavailable default models.** If the configured `grok.defaultModel` is not in the CLI's available models list on startup, the extension warns the user and falls back to the CLI's current model instead of failing the session. ([src/sidebar.ts](src/sidebar.ts))
 
 ### Changed
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,19 +7,20 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 
 find_code_cli() {
-    for name in code code-insiders; do
+    for name in antigravity-ide antigravity code code-insiders; do
         if command -v "$name" >/dev/null 2>&1; then
             echo "$name"; return 0
         fi
     done
     # macOS install paths
     for path in \
+        "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide" \
         "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" \
         "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders" \
     ; do
         [ -x "$path" ] && { echo "$path"; return 0; }
     done
-    echo "Could not find VS Code CLI. Install VS Code or add 'code' to PATH." >&2
+    echo "Could not find VS Code / Antigravity CLI. Install VS Code / Antigravity or add 'code' / 'antigravity-ide' to PATH." >&2
     return 1
 }
 
@@ -38,4 +39,4 @@ echo "Installing $vsix via $code"
 # --force so a same-version reinstall actually overwrites the installed files
 "$code" --install-extension "$vsix" --force
 echo
-echo "Done. Reload VS Code (Ctrl+Shift+P -> 'Developer: Reload Window') and click the Grok icon."
+echo "Done. Reload VS Code / Antigravity (Ctrl+Shift+P -> 'Developer: Reload Window') and click the Grok icon."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,18 +5,19 @@
 set -euo pipefail
 
 find_code_cli() {
-    for name in code code-insiders; do
+    for name in antigravity-ide antigravity code code-insiders; do
         if command -v "$name" >/dev/null 2>&1; then
             echo "$name"; return 0
         fi
     done
     for path in \
+        "/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide" \
         "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" \
         "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code-insiders" \
     ; do
         [ -x "$path" ] && { echo "$path"; return 0; }
     done
-    echo "Could not find VS Code CLI." >&2
+    echo "Could not find VS Code / Antigravity CLI." >&2
     return 1
 }
 
@@ -24,4 +25,4 @@ code=$(find_code_cli)
 echo "Uninstalling PawelHuryn.grok-vscode-phuryn via $code"
 "$code" --uninstall-extension PawelHuryn.grok-vscode-phuryn
 echo
-echo "Done. Reload VS Code to drop the sidebar."
+echo "Done. Reload VS Code / Antigravity to drop the sidebar."

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -236,7 +236,11 @@ export class AcpClient extends EventEmitter {
     this.emit("session", res);
 
     if (modelId && modelId !== this.currentModelId) {
-      await this.setModel(modelId);
+      try {
+        await this.setModel(modelId);
+      } catch (err) {
+        this.opts.log(`[acp] Failed to set model to ${modelId}: ${(err as Error).message}. Falling back to default model ${this.currentModelId}.`);
+      }
     }
     return { sessionId: res.sessionId };
   }
@@ -261,7 +265,11 @@ export class AcpClient extends EventEmitter {
     this.emit("session", { sessionId, ...(res ?? {}) });
     this.emit("sessionLoaded", { sessionId });
     if (modelId && modelId !== this.currentModelId) {
-      await this.setModel(modelId);
+      try {
+        await this.setModel(modelId);
+      } catch (err) {
+        this.opts.log(`[acp] Failed to set model to ${modelId}: ${(err as Error).message}. Keeping ${this.currentModelId}.`);
+      }
     }
     return { sessionId };
   }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1617,6 +1617,18 @@ See design doc for the full state machine diagram.`;
       }
       if (gen !== session.gen) { client.dispose(); session.client = undefined; return undefined; }
 
+      if (defaultModel && client.currentModelId && client.currentModelId !== defaultModel) {
+        const hasModel = client.availableModels.some((m) => m.modelId === defaultModel);
+        if (!hasModel) {
+          this.output.appendLine(
+            `[startup] Default model '${defaultModel}' is not available in the CLI. Using '${client.currentModelId}' instead.`,
+          );
+          vscode.window.showWarningMessage(
+            `Grok default model '${defaultModel}' is not available. Falling back to '${client.currentModelId}'. Please update your 'grok.defaultModel' setting.`,
+          );
+        }
+      }
+
       // Session is live — unlock the composer now. The "system prompt" (primer)
       // that teaches grok the plan-verdict protocol fires here EAGERLY and in the
       // BACKGROUND (not awaited), on a new OR restored session, so the composer is


### PR DESCRIPTION
This PR updates the local macOS installation and uninstallation scripts (`scripts/install.sh` and `scripts/uninstall.sh`) to detect and support **Antigravity IDE** (in addition to standard VS Code and VS Code Insiders).

Previously, when running `./scripts/install.sh`, it would fall back to installing the extension in standard Visual Studio Code even if the user was actively developing in Antigravity IDE. This change ensures the extension is correctly installed into the active Antigravity IDE environment.

#### Key Changes
* **CLI Discovery (`scripts/install.sh` & `scripts/uninstall.sh`):**
  * Added `antigravity-ide` and `antigravity` command binaries to the `find_code_cli` list of commands.
  * Added `/Applications/Antigravity IDE.app/Contents/Resources/app/bin/antigravity-ide` to the macOS fallback paths.
* **User Messages:**
  * Updated final installation/uninstallation console messages to mention "VS Code / Antigravity".

#### Verification & Testing
* Verified that `./scripts/install.sh` correctly resolves to the `antigravity-ide` binary in the PATH and successfully installs the packaged `.vsix` into the active Antigravity IDE.