### PR TITLE
fix(webview): faster inline diffs and continuous auto-scroll

### DIFF
--- a/media/chat.css
+++ b/media/chat.css
@@ -904,6 +904,12 @@ body.vscode-light {
 .diff-stat { white-space: nowrap; }
 .diff-stat-add { color: var(--tdiff-add-line); }
 .diff-stat-del { color: var(--tdiff-del-line); }
+/* Mid-turn edit totals on the group header (before the batch closes). */
+.in-progress-diff-totals {
+  white-space: nowrap;
+  font-size: inherit;
+  margin-left: 2px;
+}
 
 /* Codex-style inline diff inside the edit row's expandable detail: a line-number
    gutter, a colored left-border stripe, a subtle per-line tint, and a small +/-
@@ -921,7 +927,8 @@ body.vscode-light {
 }
 .tdl {
   display: grid;
-  grid-template-columns: 1.1ch 3ch 1fr;
+  /* sign | line# | code — line# was 3ch; digits >99 wrapped under overflow-wrap:anywhere */
+  grid-template-columns: 1.1ch 4ch 1fr;
   gap: 0 8px;
   padding-left: 7px;  /* breathing room between the colored border stripe and the +/- glyph */
   padding-right: 10px;
@@ -941,6 +948,7 @@ body.vscode-light {
   opacity: 0.75;
   user-select: none;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap; /* never wrap 3+ digit line numbers onto a second row */
 }
 .tdl-code { min-width: 0; }
 .tdl-add { background: var(--tdiff-add-bg); border-left-color: var(--tdiff-add-line); }

--- a/media/chat.js
+++ b/media/chat.js
@@ -2164,6 +2164,11 @@
       `<span class="tool-group-label">${escapeHtml(inProgressLabel(call))}</span>` +
       `<span class="tool-dots" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>` +
       `<span class="tool-chevron" aria-hidden="true">${ICON.chevronRight}</span>`;
+    // Header rebuild wipes the slot — re-paint any edit totals already attached.
+    paintInProgressDiffTotals(el);
+    // Early diff: some CLIs put old_string/new_string on the initial tool_call.
+    // Try now (toolCallUpdate path still runs if content arrives later).
+    applyToolDiffs(call);
     // A lone in-progress COMMAND is expandable immediately — its chevron shows
     // now (multi-tool groups keep theirs until the batch closes), and
     // expanding also opens the row's IN/OUT detail so one click reveals the
@@ -2473,7 +2478,10 @@
     }
     item.appendChild(details);
     wireCommandToggle(item, details, "Show the diff");
-    scrollToBottom();
+    // Live: open the group + inline diff as soon as the edit lands, so the chat
+    // tracks the on-disk change immediately (not only after the batch closes or
+    // the user expands). Replay keeps the default collapsed policy.
+    revealEditDiff(item);
   }
 
   // "+A −R" pill for an edit row (green additions, red removals). Uses a real
@@ -2506,6 +2514,44 @@
     t.files.add(path || ("__anon" + t.files.size));
   }
 
+  // While a batch is still in-progress, paint rolled-up +A −R on the group header
+  // so the user sees the edit magnitude without expanding. Survives the header
+  // rebuild that addToToolGroup does on every new call (own slot next to dots).
+  function paintInProgressDiffTotals(group) {
+    if (!group || !group.classList.contains("in-progress")) return;
+    const hdr = group.querySelector(".tool-group-header");
+    if (!hdr) return;
+    let slot = hdr.querySelector(".in-progress-diff-totals");
+    if (!slot) {
+      slot = document.createElement("span");
+      slot.className = "in-progress-diff-totals";
+      const dots = hdr.querySelector(".tool-dots");
+      if (dots) hdr.insertBefore(slot, dots);
+      else hdr.appendChild(slot);
+    }
+    while (slot.firstChild) slot.removeChild(slot.firstChild);
+    const t = group._diffTotals;
+    if (!t || (t.added === 0 && t.removed === 0)) return;
+    slot.appendChild(document.createTextNode(" · "));
+    slot.appendChild(makeDiffStat(t.added, t.removed));
+  }
+
+  // Open the group/row so a just-attached edit diff is visible mid-turn (live only).
+  function revealEditDiff(item) {
+    if (!item) return;
+    const group = item.closest && item.closest(".tool-group");
+    if (group) {
+      if (!state.replaying) {
+        setGroupExpanded(group, true);
+        setDetailExpanded(item, true);
+      }
+      paintInProgressDiffTotals(group);
+    } else if (!state.replaying) {
+      setDetailExpanded(item, true);
+    }
+    scrollToBottom();
+  }
+
   // Extract every `type:"diff"` block from a tool call's `content` and render the
   // inline edit diff. grok delivers the diff differently by path: LIVE it rides a
   // `tool_call_update` (the `tool_call` is a bare "StrReplace" with no content),
@@ -2523,17 +2569,58 @@
     labelEl.appendChild(makeDiffStat(t.added, t.removed));
   }
 
-  function applyToolDiffs(call) {
-    const c = call?.content;
-    if (!Array.isArray(c)) return;
+  // Prefer content[].type==="diff"; fall back to rawInput (old_string/new_string /
+  // Write contents) so the first tool_call can paint a preview before the
+  // completed tool_call_update arrives — cuts the "file already saved, chat still
+  // blank" lag when the CLI puts args on the initial call.
+  function extractDiffsFromCall(call) {
     const diffs = [];
-    for (const item of c) {
-      if (item?.type === "diff") {
-        diffs.push({ path: item.path, oldText: item.oldText ?? "", newText: item.newText ?? "" });
+    const c = call && call.content;
+    if (Array.isArray(c)) {
+      for (const item of c) {
+        if (item && item.type === "diff") {
+          diffs.push({
+            path: item.path || "",
+            oldText: item.oldText ?? "",
+            newText: item.newText ?? "",
+          });
+        }
       }
     }
+    if (diffs.length) return diffs;
+
+    const r = (call && (call.rawInput || call.input)) || null;
+    if (!r || typeof r !== "object") return diffs;
+    const path = r.target_file || r.filePath || r.file_path || r.path || "";
+    const ot = r.oldText != null ? r.oldText : r.old_string;
+    const nt = r.newText != null ? r.newText : r.new_string;
+    if (ot != null || nt != null) {
+      const oldText = ot == null ? "" : String(ot);
+      const newText = nt == null ? "" : String(nt);
+      if (oldText !== "" || newText !== "") {
+        diffs.push({ path, oldText, newText });
+        return diffs;
+      }
+    }
+    // Whole-file write: contents/content is the new body, old is empty.
+    const isWrite =
+      toolKind(call) === "write" ||
+      /^(write|create)\b/i.test((call && call.title) || "") ||
+      /write_file|file_write|^write$/i.test(toolName(call));
+    if (isWrite) {
+      const body = r.contents != null ? r.contents : (typeof r.content === "string" ? r.content : null);
+      if (body != null && String(body) !== "") {
+        diffs.push({ path, oldText: "", newText: String(body) });
+      }
+    }
+    return diffs;
+  }
+
+  function applyToolDiffs(call) {
+    if (!call) return;
+    const diffs = extractDiffsFromCall(call);
     if (!diffs.length) return;
-    state.pendingDiffByToolCallId.set(call.toolCallId, diffs[0]); // permission card / openDiff use the first
+    if (call.toolCallId) state.pendingDiffByToolCallId.set(call.toolCallId, diffs[0]); // permission card / openDiff use the first
     attachDiffPreviewToToolItem(call.toolCallId, diffs);
   }
 
@@ -2865,7 +2952,13 @@
       hdr.innerHTML = `<span class="thinking-icon">${ICON.brain}</span><span class="thinking-label">Thinking</span>${BLINK_DOTS}<span class="thinking-chevron" aria-hidden="true">${ICON.chevronRight}</span>`;
       const body = document.createElement("div");
       body.className = "thinking-body";
-      body.hidden = true;
+      // Live + showThinking: keep the body open while streaming so the transcript
+      // grows continuously (Claude Code-style) instead of a long collapsed quiet
+      // period followed by a sudden height jump when the answer arrives.
+      // Replay / hidden traces stay collapsed.
+      const autoOpen = !state.replaying && state.showThinking;
+      body.hidden = !autoOpen;
+      if (autoOpen) el.classList.add("expanded");
       hdr.onclick = () => {
         body.hidden = !body.hidden;
         el.classList.toggle("expanded", !body.hidden);
@@ -2875,6 +2968,12 @@
       messagesEl.appendChild(el);
       state.activeThoughtEl = body;
       state.activeThoughtHdrEl = hdr;
+    } else if (!state.replaying && state.showThinking && state.activeThoughtEl.hidden) {
+      // User (or a prior state) left it collapsed — re-open on new live chunks
+      // only while traces are enabled, so growth stays continuous.
+      state.activeThoughtEl.hidden = false;
+      const wrap = state.activeThoughtEl.parentElement;
+      if (wrap) wrap.classList.add("expanded");
     }
     state.thoughtBuffer += text;
     if (!state.thoughtRenderScheduled) {
@@ -3225,8 +3324,36 @@
   // Follow streaming output only while the user is pinned to the bottom. Once
   // they scroll up (the listener below clears state.stickToBottom) this becomes
   // a no-op, so they can read history while grok keeps thinking (#16).
+  // While the turn is live, a rAF loop keeps pinning every frame so height growth
+  // (markdown layout, newly-opened tool groups, thinking body) tracks the bottom
+  // continuously — Claude Code-style progressive follow, not a single jump after
+  // a long quiet thinking stretch.
+  let scrollFollowRaf = 0;
+  function ensureScrollFollowLoop() {
+    if (scrollFollowRaf) return;
+    const tick = () => {
+      if (!state.stickToBottom) {
+        scrollFollowRaf = 0;
+        return;
+      }
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+      if (state.busy) {
+        scrollFollowRaf = requestAnimationFrame(tick);
+      } else {
+        // One trailing frame after the turn ends catches final layout (footer,
+        // closed tool groups) without leaving a permanent loop.
+        scrollFollowRaf = requestAnimationFrame(() => {
+          scrollFollowRaf = 0;
+          if (state.stickToBottom) messagesEl.scrollTop = messagesEl.scrollHeight;
+        });
+      }
+    };
+    scrollFollowRaf = requestAnimationFrame(tick);
+  }
   function scrollToBottom() {
-    if (state.stickToBottom) messagesEl.scrollTop = messagesEl.scrollHeight;
+    if (!state.stickToBottom) return;
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    ensureScrollFollowLoop();
   }
 
   // The floating "Scroll to bottom" button (#28) shows exactly when we've stopped
@@ -3245,6 +3372,7 @@
     state.stickToBottom = true;
     messagesEl.scrollTop = messagesEl.scrollHeight;
     updateScrollBtn();
+    ensureScrollFollowLoop();
   }
 
   // While a click-triggered smooth scroll is animating, the intermediate scroll
@@ -3261,6 +3389,8 @@
     state.stickToBottom = shouldStickToBottom(
       messagesEl.scrollTop, messagesEl.scrollHeight, messagesEl.clientHeight);
     updateScrollBtn();
+    // Re-arm the follow loop if the user scrolled back to the bottom mid-turn.
+    if (state.stickToBottom && state.busy) ensureScrollFollowLoop();
   });
 
   scrollBottomBtn.onclick = () => {


### PR DESCRIPTION
## Summary

Three webview UX fixes for the chat panel (only `media/chat.js` + `media/chat.css`):

1. **Line-number gutter** — the inline-diff gutter was `3ch` and inherited `overflow-wrap: anywhere`, so numbers ≥100 wrapped mid-digit (`147` → `14` / `7`). Widened to `4ch` and set `.tdl-num { white-space: nowrap }`.

2. **Faster edit diffs** — live edits often land with `old_string`/`new_string` on the initial `tool_call` `rawInput`, while `content[].type==="diff"` arrives later on `tool_call_update`. We now:
   - extract diffs from `content` **or** `rawInput` (Write uses `contents`)
   - try `applyToolDiffs` as soon as the tool row is created
   - paint mid-turn `+A −R` on the in-progress group header
   - **live-only**: auto-expand the group + inline diff when an edit attaches (replay stays collapsed)

3. **Continuous stick-to-bottom** — long thinking then a burst of content felt like a sudden jump. While `busy && stickToBottom`, a rAF loop keeps pinning to the bottom so height growth (markdown, tools, thinking) tracks continuously. Manual scroll-up still stops following; scrolling back near the bottom re-arms. With **Show thinking** on, the live thinking body auto-opens so the transcript grows during reasoning.

## Test plan

- [ ] Edit a file with line numbers ≥100 in the inline diff — numbers stay on one line
- [ ] Live edit: `+N −M` and inline diff appear as soon as the edit is available (group expands mid-turn)
- [ ] Long thinking + long reply: chat follows the bottom continuously while pinned
- [ ] Scroll up mid-turn: auto-follow stops; scroll back to bottom: follow resumes
- [ ] Replay a session with edits: groups stay collapsed by default (no live auto-expand)
- [ ] Toggle **Show thinking** off/on: traces still hidden by `thinking-hidden` when off

## Scope

- Files: `media/chat.js`, `media/chat.css` only
- No protocol / host / CLI changes
- Intentionally does **not** change `.tool-diff-region` max-height or context trimming (left as upstream)