### PR TITLE
fix(@): missing files in autocomplete (#69)

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,6 +226,12 @@
           "default": true,
           "description": "Auto-add the active editor file as a context chip."
         },
+        "grok.mentionIndexLimit": {
+          "type": "number",
+          "default": 5000,
+          "minimum": 100,
+          "markdownDescription": "Max workspace files indexed for composer **@** file autocomplete. Default 5000 keeps a cold index build bounded; raise it (no upper limit) if files are missing from the `@` list in large repos. Applies on the next `@` after the setting changes. Very large values cost more time on the first rebuild."
+        },
         "grok.defaultEffort": {
           "type": "string",
           "enum": [

--- a/src/mention.ts
+++ b/src/mention.ts
@@ -43,6 +43,25 @@ export function normalizeRelPath(p: string): string {
 }
 
 /**
+ * Union extra `{rel, abs}` paths into a findFiles snapshot. Paths already in the
+ * map are left alone (first wins). Returns the input map unchanged when nothing
+ * new is added; otherwise a new Map so the cached findFiles snapshot stays
+ * pure. Used to inject currently open editors that the 5k cap missed (#69).
+ */
+export function mergeMentionEntries(
+  absByRel: Map<string, string>,
+  extra: Iterable<{ rel: string; abs: string }>,
+): Map<string, string> {
+  let out: Map<string, string> | null = null;
+  for (const { rel, abs } of extra) {
+    if (!rel || !abs || (out ?? absByRel).has(rel)) continue;
+    if (!out) out = new Map(absByRel);
+    out.set(rel, abs);
+  }
+  return out ?? absByRel;
+}
+
+/**
  * Combine the user's `files.exclude` + `search.exclude` maps into one findFiles
  * exclude glob. findFiles' default (undefined) applies only `files.exclude`,
  * which does NOT contain node_modules — that lives in `search.exclude` — so

--- a/src/mention.ts
+++ b/src/mention.ts
@@ -9,10 +9,26 @@
  *  and scrolls; past ~50 the ranking, not the list, is what helps). */
 export const MENTION_RESULT_LIMIT = 50;
 
-/** findFiles cap for one index build. Big monorepos exceed it — acceptable: the
- *  popover is a quick-add affordance, not a complete search surface, and the cap
- *  keeps a cold build bounded. */
+/** Default findFiles cap for one index build (also the `grok.mentionIndexLimit`
+ *  setting default). Big monorepos exceed it — the popover is a quick-add
+ *  affordance, not a complete search surface; raise the setting if files are
+ *  missing from `@` autocomplete (#69). */
 export const MENTION_INDEX_LIMIT = 5000;
+
+/** Floor for `grok.mentionIndexLimit` — tiny values make the popover useless;
+ *  there is no upper bound (the user may index an entire monorepo if they want). */
+export const MENTION_INDEX_LIMIT_MIN = 100;
+
+/**
+ * Normalize a raw `grok.mentionIndexLimit` value: floor to an integer, enforce
+ * {@link MENTION_INDEX_LIMIT_MIN}, no upper cap. Non-finite / non-positive input
+ * falls back to {@link MENTION_INDEX_LIMIT}.
+ */
+export function clampMentionIndexLimit(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return MENTION_INDEX_LIMIT;
+  return Math.max(MENTION_INDEX_LIMIT_MIN, Math.floor(n));
+}
 
 /** How long one findFiles snapshot serves queries before a rebuild. Keystrokes
  *  within a popover interaction hit the cache; newly created files appear on

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -54,7 +54,7 @@ import {
 } from "./chips";
 import { buildPromptWithImages, type PromptImageInput } from "./prompt-builder";
 import { matchSlashCommand } from "./slash-filter";
-import { MENTION_INDEX_LIMIT, MENTION_INDEX_TTL_MS, buildExcludeGlob, clampMentionIndexLimit, filterMentionFiles, normalizeRelPath, orderMentionIndex } from "./mention";
+import { MENTION_INDEX_LIMIT, MENTION_INDEX_TTL_MS, buildExcludeGlob, clampMentionIndexLimit, filterMentionFiles, mergeMentionEntries, normalizeRelPath, orderMentionIndex } from "./mention";
 import { configForcesAlwaysApprove } from "./grok-config";
 import { fileUriToPath, parseFileRef, shouldReadFileInline } from "./file-ref";
 import { pickRejectOption, shouldRejectPermission } from "./plan-gate";
@@ -215,9 +215,9 @@ export class GrokSidebar implements vscode.WebviewViewProvider {
   private chips: FileChip[] = [];
   /** Attachment-staging ops still in flight — see trackAttach. */
   private readonly pendingAttach = new Set<Promise<void>>();
-  /** The composer's `@` file popover index: workspace-relative paths (ranked by
-   *  src/mention.ts) + rel→abs map for the pick. One findFiles snapshot serves
-   *  {@link MENTION_INDEX_TTL_MS}; concurrent queries share one in-flight build. */
+  /** Cached findFiles snapshot for the `@` popover (no open-editor merge).
+   *  One snapshot serves {@link MENTION_INDEX_TTL_MS}; concurrent queries share
+   *  one in-flight build. Open tabs are layered on at read time. */
   private mentionIndex: { at: number; rels: string[]; absByRel: Map<string, string> } | null = null;
   private mentionIndexPromise: Promise<{ rels: string[]; absByRel: Map<string, string> }> | null = null;
   private editorWatcher?: vscode.Disposable;
@@ -3043,9 +3043,11 @@ See design doc for the full state machine diagram.`;
         break;
       }
       case "addMentionFile": {
-        // The pick came from a posted result, so the index (and its rel→abs map)
-        // exists; fall back to a workspace-root join if it somehow expired.
+        // Pick came from a posted result: prefer the findFiles map, then an open
+        // tab (open-only merge isn't written into the cached index, #69), then a
+        // workspace-root join if both somehow miss.
         const abs = this.mentionIndex?.absByRel.get(msg.relPath)
+          ?? this.openWorkspaceFileEntries().find((e) => e.rel === msg.relPath)?.abs
           ?? (vscode.workspace.workspaceFolders?.[0]
             ? path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, msg.relPath)
             : undefined);
@@ -3459,8 +3461,18 @@ See design doc for the full state machine diagram.`;
 
   /** The `@` popover's file index, rebuilt at most once per
    *  {@link MENTION_INDEX_TTL_MS}. Keystrokes during a cold build all await the
-   *  same findFiles pass instead of stacking one per key. */
+   *  same findFiles pass instead of stacking one per key. Open editors that the
+   *  findFiles cap missed are merged in on every read (not cached) so a newly
+   *  opened tab is mentionable immediately, and closing it drops it again (#69). */
   private async mentionFileIndex(): Promise<{ rels: string[]; absByRel: Map<string, string> }> {
+    const base = await this.mentionFindFilesIndex();
+    const merged = mergeMentionEntries(base.absByRel, this.openWorkspaceFileEntries());
+    if (merged === base.absByRel) return base;
+    return { rels: orderMentionIndex([...merged.keys()]), absByRel: merged };
+  }
+
+  /** TTL-cached `findFiles` snapshot only — no open-editor injection. */
+  private async mentionFindFilesIndex(): Promise<{ rels: string[]; absByRel: Map<string, string> }> {
     const cached = this.mentionIndex;
     if (cached && Date.now() - cached.at < MENTION_INDEX_TTL_MS) return cached;
     if (!this.mentionIndexPromise) {
@@ -3496,6 +3508,30 @@ See design doc for the full state machine diagram.`;
       if (!absByRel.has(rel)) absByRel.set(rel, uri.fsPath);
     }
     return { rels: orderMentionIndex([...absByRel.keys()]), absByRel };
+  }
+
+  /** Currently open workspace text tabs as `{rel, abs}` for mention merge.
+   *  Non-file schemes and paths outside the workspace are skipped. */
+  private openWorkspaceFileEntries(): Array<{ rel: string; abs: string }> {
+    const out: Array<{ rel: string; abs: string }> = [];
+    const seen = new Set<string>();
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        const input = tab.input;
+        if (!(input instanceof vscode.TabInputText)) continue;
+        const uri = input.uri;
+        if (uri.scheme !== "file") continue;
+        if (!vscode.workspace.getWorkspaceFolder(uri)) continue;
+        const abs = uri.fsPath;
+        if (seen.has(abs)) continue;
+        seen.add(abs);
+        out.push({
+          rel: normalizeRelPath(vscode.workspace.asRelativePath(uri)),
+          abs,
+        });
+      }
+    }
+    return out;
   }
 
   /** Resolve the xAI key for Speech-to-Text: the `grok.voiceApiKey` setting,

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -54,7 +54,7 @@ import {
 } from "./chips";
 import { buildPromptWithImages, type PromptImageInput } from "./prompt-builder";
 import { matchSlashCommand } from "./slash-filter";
-import { MENTION_INDEX_LIMIT, MENTION_INDEX_TTL_MS, buildExcludeGlob, filterMentionFiles, normalizeRelPath, orderMentionIndex } from "./mention";
+import { MENTION_INDEX_LIMIT, MENTION_INDEX_TTL_MS, buildExcludeGlob, clampMentionIndexLimit, filterMentionFiles, normalizeRelPath, orderMentionIndex } from "./mention";
 import { configForcesAlwaysApprove } from "./grok-config";
 import { fileUriToPath, parseFileRef, shouldReadFileInline } from "./file-ref";
 import { pickRejectOption, shouldRejectPermission } from "./plan-gate";
@@ -353,6 +353,11 @@ export class GrokSidebar implements vscode.WebviewViewProvider {
         // Apply the toggle immediately: disabling removes a visible context
         // chip right away (not on the next editor event), enabling shows it.
         this.refreshImplicitChip(true);
+      }
+      if (e.affectsConfiguration("grok.mentionIndexLimit")) {
+        // Drop the TTL-cached findFiles snapshot so the next `@` rebuilds with
+        // the new cap (otherwise a raise would wait up to MENTION_INDEX_TTL_MS).
+        this.mentionIndex = null;
       }
       if (e.affectsConfiguration("grok.terminalShell")) {
         this.applyTerminalShellPref();
@@ -3477,7 +3482,12 @@ See design doc for the full state machine diagram.`;
       cfg.get<Record<string, unknown>>("files.exclude"),
       cfg.get<Record<string, unknown>>("search.exclude"),
     ]);
-    const uris = await vscode.workspace.findFiles("**/*", exclude, MENTION_INDEX_LIMIT);
+    // Cap is user-tunable (`grok.mentionIndexLimit`) — large monorepos that hit
+    // the default 5000 can miss files from `@` autocomplete (#69).
+    const limit = clampMentionIndexLimit(
+      vscode.workspace.getConfiguration("grok").get<number>("mentionIndexLimit", MENTION_INDEX_LIMIT),
+    );
+    const uris = await vscode.workspace.findFiles("**/*", exclude, limit);
     const absByRel = new Map<string, string>();
     for (const uri of uris) {
       // Default asRelativePath prefixes the folder name only in a multi-root


### PR DESCRIPTION
## Summary

- Add **`grok.mentionIndexLimit`** (default 5000, min 100, no upper cap) so large workspaces can raise the `findFiles` snapshot size when `@` autocomplete misses files.
- Merge **currently open workspace text tabs** into the mention index at query time when they were not in the snapshot (e.g. past the 5k cap) — so an open file like `AreaExtensions.cs` appears under `@AreaExtensions` immediately; closing the tab stops re-injecting it.
- Picks resolve absolute paths via findFiles map → open tab → workspace-root join.

Fixes #69.

## Why

`@` indexing is a TTL-cached `workspace.findFiles("**/*", exclude, limit)`. Past the limit, VS Code returns an arbitrary subset, so real source files can be missing while unrelated hits still show via loose subsequence matching. Open editors already surface via the implicit chip but not via `@`.

## Test plan

- [x] `npm test -- test/mention.test.ts`
- [x] `npx tsc -p . --noEmit`
- [x] Manual: open a file that used to be missing from `@`, type `@basename` — it appears while the tab is open
- [x] Manual: raise **Grok › Mention Index Limit** and confirm more closed files appear after the next `@` (cache drops on setting change)
- [x] Manual: pick an open-only mention → chip attaches correctly
