### PR TITLE
Allow read-only shell during Plan mode after ask_user_question

### DIFF
--- a/src/plan-gate.ts
+++ b/src/plan-gate.ts
@@ -215,11 +215,53 @@ function isReadOnlyStage(stage: string): boolean {
     // Only allow trivially read-only invocations like `node --version`.
     return tokens.length >= 2 && /^(-v|--version|--help|-h)$/.test(tokens[1]);
   }
+  if (head === "sips") return isReadOnlySips(lowerTokens);
   if (head === "sed" && hasSedInPlace(lowerTokens.slice(1))) return false;
   if (head === "find" && hasToken(lowerTokens.slice(1), "-delete", "-exec", "-execdir", "-ok", "-okdir", "-fprint", "-fprint0", "-fprintf", "-fls")) return false;
   if (head === "fd" && hasToken(lowerTokens.slice(1), "-x", "--exec", "--exec-batch")) return false;
   if ((head === "sort" || head === "tree") && hasOutputOption(lowerTokens.slice(1))) return false;
   return READONLY_HEADS.has(head);
+}
+
+/**
+ * `sips` (macOS image tool): allow property queries only (`-g` / `--getProperty`).
+ * Resample/set/format/out forms rewrite image files and stay blocked.
+ */
+function isReadOnlySips(tokens: string[]): boolean {
+  const args = tokens.slice(1);
+  if (args.length === 0) return false;
+  let sawGet = false;
+  for (const t of args) {
+    if (t === "-g" || t === "--getproperty") {
+      sawGet = true;
+      continue;
+    }
+    if (
+      t === "-s" || t.startsWith("--set") ||
+      t === "-z" || t.startsWith("--resample") ||
+      t === "-r" || t.startsWith("--rotate") ||
+      t === "-f" || t.startsWith("--format") ||
+      t === "-o" || t.startsWith("--out") ||
+      t === "-d" || t.startsWith("--delete") ||
+      t.startsWith("--crop") || t.startsWith("--pad") ||
+      t === "--addicon" || t === "--optimizecolorforsharing"
+    ) {
+      return false;
+    }
+  }
+  return sawGet;
+}
+
+/**
+ * Drop redirects that cannot write workspace state (`2>/dev/null`, `>/dev/null`,
+ * `2>&1`). Agents often silence noise on inspect commands; those must not flip
+ * the whole chain to "unsafe" while real `> out.txt` redirects still block.
+ */
+function stripNullRedirects(cmd: string): string {
+  return cmd
+    .replace(/(?:\d+)?\s*>\s*\/dev\/null\b/gi, " ")
+    .replace(/&\s*>\s*\/dev\/null\b/gi, " ")
+    .replace(/(?:\d+)?\s*>&\s*\d+/g, " ");
 }
 
 /**
@@ -230,10 +272,16 @@ function isReadOnlyStage(stage: string): boolean {
  * program (with a read-only subcommand for git/npm/pnpm/yarn). So
  * `cd repo && git status` and `Get-ChildItem | Select-Object` pass, but
  * `cd repo && npm install`, `git status; rm -rf x`, and `cat x | iex` do not.
- * Everything else is blocked. Errs toward blocking.
+ * Harmless `2>/dev/null` redirects are stripped first. Everything else is
+ * blocked. Errs toward blocking.
  */
 export function isReadOnlyCommand(command: string): boolean {
-  const cmd = String(command || "").trim();
+  const raw = String(command || "").trim();
+  if (!raw) return false;
+  // Newlines are shell statement separators — refuse before we collapse
+  // whitespace (otherwise `ls\nrm -rf x` would look like `ls rm -rf x`).
+  if (/[\r\n]/.test(raw)) return false;
+  const cmd = stripNullRedirects(raw).replace(/[ \t]+/g, " ").trim();
   if (!cmd) return false;
   if (UNSAFE_SHELL.test(cmd)) return false;
   if (cmd.replace(/&&/g, "").includes("&")) return false; // lone & = backgrounding
@@ -298,9 +346,71 @@ export function shouldBlockTerminal(command: string, ctx: PlanGateContext): bool
   return true;
 }
 
-/** Should a `session/request_permission` for `toolKind` be auto-rejected? */
-export function shouldRejectPermission(toolKind: string | undefined, ctx: PlanGateContext): boolean {
-  return ctx.active && isMutatingKind(toolKind);
+export interface PlanPermissionInput {
+  /** ACP tool-call kind (`edit` / `execute` / `read` / …). */
+  kind?: string;
+  /**
+   * Shell command when `kind` is `execute` (from `toolCall.rawInput.command`).
+   * Used so read-only exploration is not auto-rejected during planning.
+   */
+  command?: string;
+}
+
+/**
+ * Notice when plan mode auto-rejects a mutating permission. Deliberately does
+ * **not** say only "approve the plan first" — users often just answered an
+ * `ask_user_question` card and think that counted as approval. Answering
+ * questions is not plan approval; the plan review card is.
+ */
+export const PLAN_PERMISSION_BLOCKED_MSG =
+  "Plan mode is still active — that action was blocked. Answering questions is not plan approval; wait for the plan review card, then Approve to implement.";
+
+/**
+ * Should a `session/request_permission` be auto-rejected while planning?
+ *
+ * - `edit` / `delete` / `move` / `write` → always reject (implementation).
+ * - `execute` → reject unless the command is known read-only (same allowlist as
+ *   `shouldBlockTerminal`). Missing/unknown command errs toward reject.
+ * - other kinds → allow through (read/search/fetch/etc.).
+ */
+export function shouldRejectPermission(
+  toolKind: string | undefined,
+  ctx: PlanGateContext,
+  input?: PlanPermissionInput,
+): boolean {
+  if (!ctx.active) return false;
+  const kind = String(toolKind ?? input?.kind ?? "").toLowerCase();
+  if (kind === "execute") {
+    const cmd = input?.command;
+    return !cmd || !isReadOnlyCommand(cmd);
+  }
+  return isMutatingKind(kind);
+}
+
+/**
+ * Should a permission be auto-allowed while planning (no card, no notice)?
+ * Mirrors the terminal gate: only read-only `execute` commands.
+ */
+export function shouldAutoAllowPermission(
+  toolKind: string | undefined,
+  ctx: PlanGateContext,
+  input?: PlanPermissionInput,
+): boolean {
+  if (!ctx.active) return false;
+  const kind = String(toolKind ?? input?.kind ?? "").toLowerCase();
+  if (kind !== "execute") return false;
+  const cmd = input?.command;
+  return !!cmd && isReadOnlyCommand(cmd);
+}
+
+/** Pull the shell command out of an ACP permission toolCall, if present. */
+export function commandFromPermissionToolCall(toolCall: {
+  rawInput?: unknown;
+} | undefined): string | undefined {
+  const ri = toolCall?.rawInput;
+  if (!ri || typeof ri !== "object") return undefined;
+  const cmd = (ri as { command?: unknown }).command;
+  return typeof cmd === "string" && cmd.trim() ? cmd : undefined;
 }
 
 export interface PermissionOptionLike {
@@ -320,6 +430,20 @@ export function pickRejectOption(options: PermissionOptionLike[]): string | unde
   if (exact) return exact.optionId;
   const anyReject = options.find((o) => /reject|deny|cancel|no/i.test(o.kind));
   return anyReject?.optionId;
+}
+
+/**
+ * Pick the option that means "yes". Prefers `allow_always`, then `allow_once`,
+ * then any allow/accept kind.
+ */
+export function pickAllowOption(options: PermissionOptionLike[]): string | undefined {
+  if (!Array.isArray(options) || options.length === 0) return undefined;
+  const always = options.find((o) => o.kind === "allow_always");
+  if (always) return always.optionId;
+  const once = options.find((o) => o.kind === "allow_once");
+  if (once) return once.optionId;
+  const anyAllow = options.find((o) => /allow|accept|yes/i.test(o.kind));
+  return anyAllow?.optionId;
 }
 
 /**

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -77,7 +77,14 @@ import {
   unreferencedUploadsForRemovedSessions,
 } from "./file-upload";
 import { MAX_DIFF_EXPAND_BYTES, expandDiffToWholeFile } from "./diff-view";
-import { pickRejectOption, shouldRejectPermission } from "./plan-gate";
+import {
+  PLAN_PERMISSION_BLOCKED_MSG,
+  commandFromPermissionToolCall,
+  pickAllowOption,
+  pickRejectOption,
+  shouldAutoAllowPermission,
+  shouldRejectPermission,
+} from "./plan-gate";
 import { appendPlanEntry, planRestoreSource, truncateResolvedAfter, countsAsUserBubble, decideRestoreState } from "./plan-restore";
 import { planReviewFileName, sanitizePlanReviewFilePart } from "./plan-review";
 import { GROK_PRIMER, isPrimerText, isPrimerSummary } from "./grok-primer";
@@ -2811,24 +2818,35 @@ See design doc for the full state machine diagram.`;
     });
     client.on("permissionRequest", (req: PermissionRequest) => {
       if (gen !== session.gen) return;
-      // While planning, decline any mutating permission outright. Agent mode
-      // skips this prompt for edits it deems safe — the fs/terminal gate is the
-      // real backstop — but if the CLI *does* ask, we say no without bothering
-      // the user.
-      if (session.planActive && shouldRejectPermission(req.toolCall?.kind, {
-        active: true,
-        workspaceRoot: cwd,
-      })) {
-        const rejectId = pickRejectOption(req.options);
-        if (rejectId) {
-          client.respondPermission(req.id, rejectId);
-          this.emit(session, {
-            type: "planNotice",
-            text: `Plan mode declined a ${req.toolCall?.kind ?? "tool"} request — approve the plan first.`,
-          });
-          return;
+      // While planning: auto-allow read-only shell (same allowlist as the
+      // terminal gate) so the post–ask_user_question continue turn can keep
+      // exploring; auto-reject true mutations. Answering questions is NOT plan
+      // approval — the notice text makes that explicit.
+      if (session.planActive) {
+        const planCtx = { active: true as const, workspaceRoot: cwd };
+        const permInput = {
+          kind: req.toolCall?.kind,
+          command: commandFromPermissionToolCall(req.toolCall),
+        };
+        if (shouldAutoAllowPermission(req.toolCall?.kind, planCtx, permInput)) {
+          const allowId = pickAllowOption(req.options);
+          if (allowId) {
+            client.respondPermission(req.id, allowId);
+            return;
+          }
         }
-        // No decline option offered — fall through and let the user decide.
+        if (shouldRejectPermission(req.toolCall?.kind, planCtx, permInput)) {
+          const rejectId = pickRejectOption(req.options);
+          if (rejectId) {
+            client.respondPermission(req.id, rejectId);
+            this.emit(session, {
+              type: "planNotice",
+              text: PLAN_PERMISSION_BLOCKED_MSG,
+            });
+            return;
+          }
+          // No decline option offered — fall through and let the user decide.
+        }
       }
       if (session.autoApprove) {
         const opt = req.options.find((o) => o.kind === "allow_always") ??

--- a/test/plan-gate.test.ts
+++ b/test/plan-gate.test.ts
@@ -5,10 +5,14 @@ import {
   isReadOnlyCommand,
   isPlanFileWrite,
   isGrokPlanWriteCommand,
+  pickAllowOption,
   pickRejectOption,
   shouldBlockWrite,
   shouldBlockTerminal,
+  shouldAutoAllowPermission,
   shouldRejectPermission,
+  commandFromPermissionToolCall,
+  PLAN_PERMISSION_BLOCKED_MSG,
   PlanGateContext,
 } from "../src/plan-gate";
 
@@ -291,11 +295,43 @@ describe("permission gating", () => {
     expect(isMutatingKind(undefined)).toBe(false);
   });
 
-  it("auto-rejects mutating permission requests only while planning", () => {
+  it("auto-rejects edit/delete while planning; leaves read alone", () => {
     expect(shouldRejectPermission("edit", active("/p"))).toBe(true);
-    expect(shouldRejectPermission("execute", active("/p"))).toBe(true);
+    expect(shouldRejectPermission("delete", active("/p"))).toBe(true);
     expect(shouldRejectPermission("read", active("/p"))).toBe(false);
     expect(shouldRejectPermission("edit", off("/p"))).toBe(false);
+  });
+
+  it("execute: rejects mutating/unknown commands, allows read-only while planning", () => {
+    // No command (or missing) → reject (can't prove read-only).
+    expect(shouldRejectPermission("execute", active("/p"))).toBe(true);
+    expect(shouldRejectPermission("execute", active("/p"), {})).toBe(true);
+    expect(shouldRejectPermission("execute", active("/p"), { command: "npm install" })).toBe(true);
+    // Read-only exploration (incl. the logo/PWA inspect shape) → do NOT reject.
+    expect(shouldRejectPermission("execute", active("/p"), { command: "git status" })).toBe(false);
+    expect(shouldRejectPermission("execute", active("/p"), {
+      command: "file frontend/public/logo.png && sips -g pixelWidth -g pixelHeight frontend/public/logo.png; ls -la frontend/public",
+    })).toBe(false);
+    // Gate off → never reject.
+    expect(shouldRejectPermission("execute", off("/p"), { command: "rm -rf x" })).toBe(false);
+  });
+
+  it("shouldAutoAllowPermission only for read-only execute while planning", () => {
+    expect(shouldAutoAllowPermission("execute", active("/p"), { command: "ls -la" })).toBe(true);
+    expect(shouldAutoAllowPermission("execute", active("/p"), { command: "npm install" })).toBe(false);
+    expect(shouldAutoAllowPermission("edit", active("/p"))).toBe(false);
+    expect(shouldAutoAllowPermission("execute", off("/p"), { command: "ls" })).toBe(false);
+  });
+
+  it("commandFromPermissionToolCall reads rawInput.command", () => {
+    expect(commandFromPermissionToolCall({ rawInput: { command: "git status" } })).toBe("git status");
+    expect(commandFromPermissionToolCall({ rawInput: {} })).toBeUndefined();
+    expect(commandFromPermissionToolCall(undefined)).toBeUndefined();
+  });
+
+  it("notice text clarifies that answering questions is not plan approval", () => {
+    expect(PLAN_PERMISSION_BLOCKED_MSG.toLowerCase()).toContain("answering questions is not plan approval");
+    expect(PLAN_PERMISSION_BLOCKED_MSG.toLowerCase()).toContain("plan review");
   });
 
   it("pickRejectOption prefers reject_once, falls back, and bails when none", () => {
@@ -309,6 +345,42 @@ describe("permission gating", () => {
     ])).toBe("y");
     expect(pickRejectOption([{ optionId: "x", kind: "allow_once" }])).toBeUndefined();
     expect(pickRejectOption([])).toBeUndefined();
+  });
+
+  it("pickAllowOption prefers allow_always, then allow_once", () => {
+    expect(pickAllowOption([
+      { optionId: "r", kind: "reject_once" },
+      { optionId: "a", kind: "allow_once" },
+      { optionId: "aa", kind: "allow_always" },
+    ])).toBe("aa");
+    expect(pickAllowOption([
+      { optionId: "r", kind: "reject_once" },
+      { optionId: "a", kind: "allow_once" },
+    ])).toBe("a");
+    expect(pickAllowOption([{ optionId: "r", kind: "reject_once" }])).toBeUndefined();
+  });
+});
+
+describe("isReadOnlyCommand — sips + null redirects", () => {
+  it("allows property queries (-g) used for PWA icon sizing", () => {
+    expect(isReadOnlyCommand("sips -g pixelWidth -g pixelHeight frontend/public/logo.png")).toBe(true);
+    // Exact command from a live banking-session plan turn (incl. 2>/dev/null).
+    expect(isReadOnlyCommand(
+      "file frontend/public/logo.png frontend/public/logo.svg && sips -g pixelWidth -g pixelHeight frontend/public/logo.png 2>/dev/null; ls -la frontend/public/",
+    )).toBe(true);
+  });
+
+  it("blocks mutating sips forms", () => {
+    expect(isReadOnlyCommand("sips -z 192 192 logo.png --out icon-192.png")).toBe(false);
+    expect(isReadOnlyCommand("sips -s format jpeg logo.png")).toBe(false);
+    expect(isReadOnlyCommand("sips logo.png")).toBe(false); // no -g → not a query
+  });
+
+  it("allows >/dev/null noise redirects but still blocks real file redirects", () => {
+    expect(isReadOnlyCommand("ls 2>/dev/null")).toBe(true);
+    expect(isReadOnlyCommand("git status >/dev/null 2>&1")).toBe(true);
+    expect(isReadOnlyCommand("cat secrets > out.txt")).toBe(false);
+    expect(isReadOnlyCommand("ls 2>/tmp/err.txt")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the Plan-mode UX where, after the user answers an `ask_user_question` card, the agent continues exploring but the next **read-only shell** (`file` / `sips -g` / `ls`, etc.) is auto-rejected with a misleading notice:

> Plan mode declined a execute request — approve the plan first.

Answering questions is not plan approval. While planning, inspection should keep working; only real mutations stay blocked until the **plan review** card is approved.

Closes #89

## What changed

- **Permission gate** aligns with the terminal allowlist: `execute` is auto-**allowed** when `isReadOnlyCommand(command)`; `edit` / write / mutating execute still auto-**reject**.
- **Notice text** states that answering questions is not plan approval and points users at the plan review card.
- **Allowlist polish:** `sips -g` / `--getProperty` (macOS image inspect), strip harmless `2>/dev/null` / `2>&1` before unsafe checks; keep real redirects blocked.
- Unit tests for the above in `test/plan-gate.test.ts`.

## Test plan

- [x] `npm test` (full suite green locally)
- [x] Manual: Plan mode → answer question card → agent runs a read-only shell explore → should **not** show the old decline notice
- [x] Manual: Plan mode → mutating command / workspace write → still blocked until plan review **Approve**
- [x] Manual: Approve plan on review card → implementation proceeds as before