### PR TITLE
Enhance local server status checking to ensure it is still marked as ready when the health status is missing.

### DIFF
--- a/media/settings.js
+++ b/media/settings.js
@@ -1271,6 +1271,17 @@
     return parts.join(" · ");
   }
 
+  // Local config servers commonly report whether they are enabled but do not
+  // include a health/status field. They are still usable in that state. An
+  // explicit status (including an error or an in-progress state) remains the
+  // authoritative display signal, and an explicit enabled:false must never
+  // get a green dot from a stale "ready" status.
+  function mcpServerIsReady(server) {
+    if (server.enabled === false) return false;
+    if (server.error || server.status === "unavailable") return false;
+    return !server.status || server.status === "ready";
+  }
+
   function mcpIsManagedServer(server) {
     return !!(server && (server.managed === true || server.source === "managed"));
   }
@@ -1337,7 +1348,7 @@
       const name = document.createElement("div");
       name.className = "settings-mcp-name settings-row-title";
       const status = document.createElement("span");
-      status.className = "settings-mcp-status" + (server.status === "ready" ? " is-ready" : (server.error || server.status === "unavailable" ? " is-error" : ""));
+      status.className = "settings-mcp-status" + (mcpServerIsReady(server) ? " is-ready" : (server.error || server.status === "unavailable" ? " is-error" : ""));
       status.setAttribute("aria-hidden", "true");
       name.appendChild(status);
       const label = document.createElement("span");

--- a/test/settings-surface.dom.test.ts
+++ b/test/settings-surface.dom.test.ts
@@ -451,6 +451,9 @@ describe("settings overlay (chat.js)", () => {
     expect(overlay.textContent).not.toContain("grok.com managed");
     expect(overlay.textContent).toContain("32 tools");
     expect(overlay.textContent).toContain("Disabled · ready · 0 tools");
+    const lists = overlay.querySelectorAll('[data-id="mcpCatalog"] .settings-mcp-list');
+    const localStatus = lists[1]?.querySelector(".settings-mcp-status");
+    expect(localStatus?.classList.contains("is-ready")).toBe(false);
     expect(overlay.textContent).toMatch(/follow your Grok account/);
     expect(overlay.textContent).toMatch(/Grok config files/);
     expect(overlay.querySelector(".settings-switch")).toBeNull();
@@ -472,6 +475,28 @@ describe("settings overlay (chat.js)", () => {
     expect(overlay.querySelectorAll(".settings-mcp-list .settings-mcp-open")).toHaveLength(0);
     click(h.window, fileOpen);
     expect(h.posted).toContainEqual({ type: "openGlobalConfig" });
+  });
+
+  it("marks an enabled local server ready when its inventory omits health status", () => {
+    const h = bootWebview();
+    seedChat(h, { capabilities: { mcpSettings: true } });
+    openSettings(h);
+    clickSettingsNav(h, "Connectors");
+    dispatch(h.window, {
+      type: "mcpServers",
+      servers: [{
+        name: "chrome-devtools",
+        source: "local",
+        enabled: true,
+        command: "npx",
+        args: ["chrome-devtools-mcp@latest"],
+      }],
+      warning: "This list is read-only.",
+    });
+    const row = h.doc.querySelector('[data-id="mcpCatalog"] .settings-mcp-list .settings-mcp-server')!;
+    expect(row.querySelector(".settings-mcp-status")?.classList.contains("is-ready")).toBe(true);
+    expect(row.textContent).not.toContain("Disabled");
+    expect(row.textContent).toContain("npx chrome-devtools-mcp@latest");
   });
 
   it("shows Local Open in the section header even when the section is empty", () => {


### PR DESCRIPTION
Minor fix to make the local server’s status visible in real time.

Before:

The local server is online and accessible by Grok Build, but the settings page still shows a gray 'unavailable' status.
<img width="1615" height="733" alt="image" src="https://github.com/user-attachments/assets/5e11a572-5ddb-4cec-9da3-e52f13bd59db" />

After:
<img width="1080" height="720" alt="image" src="https://github.com/user-attachments/assets/ef75c5e4-7d32-4e23-a245-664d3481cccc" />

