### PR TITLE
feat(desktop): discrete prompt queue with drag-and-drop reordering

### DIFF
--- a/docs/superpowers/plans/2026-09-12-discrete-prompt-queue-plan.md
+++ b/docs/superpowers/plans/2026-09-12-discrete-prompt-queue-plan.md
@@ -1,0 +1,384 @@
+# Discrete Prompt Queue & Reordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Modify the host and UI so that multiple pending prompts form a discrete queue processed one-by-one, with UI cards that can be reordered via drag-and-drop.
+
+**Architecture:** 
+- The host (`sidebar.ts` & `queued-send.ts`) shifts from executing the entire queue array joined by newlines to shifting only the first element per turn completion. 
+- The protocol adds new events (`reorderQueuedSends`) and amends existing ones (`dequeueSend`, `steerSend`) to carry an `index` parameter targeting specific items.
+- The webview UI (`media/chat.js`) renders a list of `div` cards mapping to `state.sendQueue`, equipped with HTML5 Drag-and-Drop event handlers and explicit card actions (Steer, Edit, Remove).
+
+**Tech Stack:** TypeScript, Node.js, DOM API (Vanilla JS for Webview).
+
+## Global Constraints
+- Target workspace: `grok-build-vscode`
+- Testing: TypeScript strict mode must pass; existing Vitest suites must be updated to pass.
+- No new external drag-and-drop dependencies; use HTML5 native `draggable="true"` and DOM events.
+- Maintain isolation per session `Session.queuedSends`.
+
+---
+
+### Task 1: Protocol and Host Base Logic for Queue Reordering & Sequential Flushing
+
+**Files:**
+- Modify: `src/protocol.ts`
+- Modify: `src/queued-send.ts`
+- Modify: `src/sidebar.ts`
+- Test: `test/sidebar.test.ts` or `test/queued-send.test.ts` (existing suites).
+
+**Interfaces:**
+- Produces: `reorderQueuedSends(items: QueuedSendEntry[], fromIndex: number, toIndex: number): QueuedSendEntry[]`
+- Produces: WebviewMessage `reorderQueuedSends` and HostMessage adjustments for targeted editing/steering.
+
+- [ ] **Step 1: Update Protocol Types**
+
+Update `src/protocol.ts` to include the new host message and enhance existing ones.
+Add to `HostMsg` union:
+```typescript
+  | { type: "reorderQueuedSends"; fromIndex: number; toIndex: number }
+  | { type: "dequeueSend"; index: number } // ensure index exists
+  | { type: "steerSend"; text: string; chips?: FileChip[]; fromQueue?: boolean; index?: number }
+```
+
+- [ ] **Step 2: Add Reorder Helper to `queued-send.ts`**
+
+In `src/queued-send.ts`, add the reorder logic.
+```typescript
+export function reorderQueuedSends(
+  items: readonly QueuedSendEntry[],
+  fromIndex: number,
+  toIndex: number,
+): QueuedSendEntry[] {
+  if (fromIndex < 0 || fromIndex >= items.length || toIndex < 0 || toIndex >= items.length) {
+    return [...items];
+  }
+  const result = [...items];
+  const [moved] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, moved);
+  return result;
+}
+```
+
+- [ ] **Step 3: Modify `sidebar.ts` Flush Logic**
+
+In `src/sidebar.ts`, locate `queuedSendReadyText()` and `maybeFlushQueuedSends()` routines around line 3915.
+Instead of:
+```typescript
+return queuedFlushText(session.queuedSends); // returns joined string
+```
+Modify to:
+```typescript
+private queuedSendReadyText(session: Session): string | undefined {
+  if (!sessionReadyForPrompt(session)) return undefined;
+  if (session.status === "working" || session.status === "needs-you") return undefined;
+  if (session.queuedSends.length === 0) return undefined;
+  return queuedFlushText([session.queuedSends[0]]);
+}
+```
+
+And in `maybeFlushQueuedSends()` where `session.queuedSends = []` is called when clearing the queue for execution (around line 4000):
+```typescript
+if (takeQueue) {
+  // Only shift the first item for execution
+  contributions = [{
+    text: session.queuedSends[0].text,
+    chips: session.queuedSends[0].chips.map(cloneChipForQueue),
+  }];
+  session.queuedSends = session.queuedSends.slice(1);
+  session.queuedSendDispatch = undefined;
+  session.queuedSendCommit = undefined;
+  this.emitQueuedSends(session);
+}
+```
+
+- [ ] **Step 4: Wire Webview-to-Host Messages in `sidebar.ts`**
+
+In `src/sidebar.ts` inside the `switch (message.type)` handler (around line 10760+):
+```typescript
+case "reorderQueuedSends": {
+  const s = requireSession(message.sessionId);
+  s.queuedSends = reorderQueuedSends(s.queuedSends, message.fromIndex, message.toIndex);
+  this.emitQueuedSends(s);
+  break;
+}
+```
+Update `"dequeueSend"`:
+```typescript
+case "dequeueSend": {
+  // Pass message.index explicitly. It defaults to 0 if not provided for legacy support.
+  const idx = typeof message.index === "number" ? message.index : 0;
+  const result = dequeueQueuedSends(s.queuedSends, idx, false);
+  // ... existing logic to prepend text to composer ...
+}
+```
+Update `"steerSend"`:
+```typescript
+case "steerSend": {
+  const s = requireSession(message.sessionId);
+  if (message.fromQueue && typeof message.index === "number") {
+    // Remove only the steered item from the queue
+    const res = dequeueQueuedSends(s.queuedSends, message.index, false);
+    if (res) s.queuedSends = res.rest;
+    this.emitQueuedSends(s);
+  } else if (message.fromQueue) {
+    // Legacy fallback: clear the whole queue
+    s.queuedSends = [];
+    this.emitQueuedSends(s);
+  }
+  // ... existing steer setup logic ...
+}
+```
+
+- [ ] **Step 5: Run tests to verify host state**
+
+Run: `vitest run test/queued-send.test.ts test/sidebar.test.ts -v` (or run full suite `pnpm test`)
+Expected: PASS. If tests fail due to the change from combined execution to sequential execution, update the test snapshots or logic to expect single-item execution.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/protocol.ts src/queued-send.ts src/sidebar.ts
+git commit -m "feat(host): implement sequential queue flushing and reorder logic"
+```
+
+---
+
+### Task 2: Webview Multi-Card Queue Rendering & Drag-and-Drop
+
+**Files:**
+- Modify: `media/chat.js`
+- Modify: `media/chat.css`
+
+**Interfaces:**
+- Consumes: The `state.sendQueue` array from the webview state containing `{ text, chips }`.
+
+- [ ] **Step 1: CSS Updates for Drag-and-Drop & Cards**
+
+In `media/chat.css`, add styles for the individual cards and drag interactions:
+```css
+.queued-msgs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+.queued-item {
+  position: relative;
+  border-radius: 6px;
+  background: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-widget-border);
+  cursor: grab;
+  padding: 8px;
+}
+.queued-item:active {
+  cursor: grabbing;
+}
+.queued-item.drag-over-above {
+  border-top: 2px solid var(--vscode-focusBorder);
+}
+.queued-item.drag-over-below {
+  border-bottom: 2px solid var(--vscode-focusBorder);
+}
+.queued-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+  font-size: 0.9em;
+  color: var(--vscode-descriptionForeground);
+}
+.queued-item-actions {
+  display: flex;
+  gap: 4px;
+}
+.queued-item-actions button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 2px 4px;
+}
+```
+
+- [ ] **Step 2: Re-write `renderQueuedBlocks` in `media/chat.js`**
+
+Replace the logic that builds a single DOM element with logic that builds a list of elements.
+```javascript
+function renderQueuedBlocks() {
+  let wrap = state.queuedWrapEl;
+  if (!state.sendQueue || state.sendQueue.length === 0) {
+    if (wrap) wrap.remove();
+    state.queuedWrapEl = null;
+    return;
+  }
+  
+  if (!wrap || !wrap.isConnected) {
+    wrap = document.createElement("div");
+    wrap.className = "queued-msgs-list";
+    state.queuedWrapEl = wrap;
+  }
+  wrap.innerHTML = "";
+  
+  state.sendQueue.forEach((item, index) => {
+    const card = document.createElement("div");
+    card.className = "queued-item msg user queued";
+    card.draggable = true;
+    card.dataset.index = index;
+    
+    // Drag and drop event listeners
+    card.addEventListener("dragstart", (e) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", index.toString());
+      card.style.opacity = "0.5";
+    });
+    card.addEventListener("dragend", () => {
+      card.style.opacity = "1";
+      document.querySelectorAll(".queued-item").forEach(el => {
+        el.classList.remove("drag-over-above", "drag-over-below");
+      });
+    });
+    card.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      const rect = card.getBoundingClientRect();
+      const mid = rect.top + rect.height / 2;
+      if (e.clientY < mid) {
+        card.classList.add("drag-over-above");
+        card.classList.remove("drag-over-below");
+      } else {
+        card.classList.add("drag-over-below");
+        card.classList.remove("drag-over-above");
+      }
+    });
+    card.addEventListener("dragleave", () => {
+      card.classList.remove("drag-over-above", "drag-over-below");
+    });
+    card.addEventListener("drop", (e) => {
+      e.preventDefault();
+      card.classList.remove("drag-over-above", "drag-over-below");
+      const fromIndex = parseInt(e.dataTransfer.getData("text/plain"), 10);
+      let toIndex = index;
+      const rect = card.getBoundingClientRect();
+      if (e.clientY >= rect.top + rect.height / 2) {
+        toIndex += 1;
+      }
+      if (fromIndex < toIndex) toIndex -= 1; // adjust for shift
+      if (fromIndex !== toIndex) {
+        vscode.postMessage({ type: "reorderQueuedSends", fromIndex, toIndex, sessionId: state.activeSessionId });
+      }
+    });
+    
+    // Header & Actions
+    const header = document.createElement("div");
+    header.className = "queued-item-header queued-hdr";
+    const tag = document.createElement("span");
+    tag.className = "queued-tag";
+    tag.innerHTML = `${ICON.clock}<span>Queued #${index + 1}</span>`;
+    header.appendChild(tag);
+    
+    const actions = document.createElement("div");
+    actions.className = "queued-item-actions queued-actions";
+    
+    // Edit Button
+    const editBtn = document.createElement("button");
+    editBtn.title = "Edit (removes from queue)";
+    editBtn.innerHTML = `${ICON.edit} Edit`;
+    editBtn.onclick = () => {
+      vscode.postMessage({ type: "dequeueSend", index, sessionId: state.activeSessionId });
+    };
+    actions.appendChild(editBtn);
+    
+    // Remove Button
+    const removeBtn = document.createElement("button");
+    removeBtn.title = "Remove";
+    removeBtn.innerHTML = `${ICON.close}`;
+    removeBtn.onclick = () => {
+      // In host side, dequeueSend without putting it back in composer needs special handling, 
+      // or we can reuse `cancelSubmission` behavior directed at an index.
+      // Easiest is adding a specific `removeQueuedSend` or passing a flag to `dequeueSend`.
+      vscode.postMessage({ type: "removeQueuedSend", index, sessionId: state.activeSessionId });
+    };
+    actions.appendChild(removeBtn);
+    
+    header.appendChild(actions);
+    card.appendChild(header);
+    
+    // Content body
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+    const content = document.createElement("div");
+    content.className = "msg-content text-content";
+    content.textContent = item.text || "";
+    bubble.appendChild(content);
+    
+    // Chips logic (if any)
+    if (item.chips && item.chips.length > 0) {
+      const chipContainer = document.createElement("div");
+      chipContainer.className = "chips-row msg-chips";
+      item.chips.forEach(chip => {
+        const c = document.createElement("div");
+        c.className = "chip file-chip";
+        c.textContent = chip.label || chip.id;
+        chipContainer.appendChild(c);
+      });
+      bubble.appendChild(chipContainer);
+    }
+    
+    card.appendChild(bubble);
+    
+    // Steer Action (if applicable)
+    if (state.steerSupported && steerableProvider()) {
+      const steerBtn = document.createElement("button");
+      steerBtn.className = "queued-action queued-steer";
+      steerBtn.innerHTML = `${ICON.cornerDownRight}<span>Steer</span>`;
+      steerBtn.onpointerdown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (state.sessionSuperseded) return;
+        vscode.postMessage({ type: "steerSend", text: item.text, chips: item.chips, fromQueue: true, index, sessionId: state.activeSessionId });
+      };
+      card.appendChild(steerBtn);
+    }
+    
+    wrap.appendChild(card);
+  });
+  
+  const bottomAnchor = document.getElementById("bottom-anchor");
+  if (bottomAnchor && bottomAnchor.parentNode) {
+    bottomAnchor.parentNode.insertBefore(wrap, bottomAnchor);
+  }
+}
+```
+
+- [ ] **Step 3: Missing `removeQueuedSend` Protocol Support**
+
+Because step 2 introduces a pure remove button, add it to `protocol.ts` and `sidebar.ts`.
+In `protocol.ts`:
+```typescript
+| { type: "removeQueuedSend"; index: number }
+```
+In `sidebar.ts` inside the webview message switch:
+```typescript
+case "removeQueuedSend": {
+  const s = requireSession(message.sessionId);
+  if (message.index >= 0 && message.index < s.queuedSends.length) {
+    s.queuedSends = [...s.queuedSends.slice(0, message.index), ...s.queuedSends.slice(message.index + 1)];
+    if (!s.queuedSends.length) s.queuedSendRequiresRelay = false;
+    this.emitQueuedSends(s);
+  }
+  break;
+}
+```
+
+- [ ] **Step 4: Verify in Webview tests**
+
+Run: `vitest run test/webview-ui.dom.test.ts`
+Expected: Passes. (Update snapshot or test expectations for queued render structure).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add media/chat.js media/chat.css src/protocol.ts src/sidebar.ts
+git commit -m "feat(ui): render distinct queued cards with drag-and-drop reordering"
+```

--- a/docs/superpowers/specs/2026-09-12-discrete-prompt-queue-design.md
+++ b/docs/superpowers/specs/2026-09-12-discrete-prompt-queue-design.md
@@ -1,0 +1,75 @@
+# Discrete Prompt Queue & Reordering Specification
+
+**Date:** 2026-09-12  
+**Feature:** Discrete Per-Conversation Prompt Queue & Drag-and-Drop Reordering  
+**Target Repository:** `grok-build-vscode`  
+
+---
+
+## 1. Overview & Objectives
+
+Currently, when multiple prompts are sent while an agent is busy processing a turn, all pending messages are merged into a single queued text block and executed together as one combined prompt when the turn completes. 
+
+This specification introduces **Discrete Prompt Queueing**:
+1. **Sequential Execution (FIFO):** Each prompt submitted during an active turn forms a distinct queued item. When the turn finishes, only the first prompt in the queue is executed. When that subsequent turn completes, the next queued prompt executes, continuing until the queue is exhausted.
+2. **Per-Item UI Cards:** Each queued prompt renders as an individual card in the webview with order indicators (`#1`, `#2`, etc.) and individual action controls (`Edit`, `Remove`, `Steer`).
+3. **Drag-and-Drop Reordering:** Users can reorder queued prompts by dragging and dropping cards to change their execution sequence.
+4. **Session Isolation:** Queue state remains strict and isolated per conversation session (`Session.queuedSends`), so switching sessions or workspace projects updates the queue view seamlessly.
+
+---
+
+## 2. Component & Data Flow Changes
+
+### A. Protocol & Messages (`src/protocol.ts`)
+Add host-webview message types for individual queue manipulation:
+- `reorderQueuedSends`: sent from Webview to Host with payload `{ fromIndex: number, toIndex: number }` or `{ newOrder: number[] }`.
+- `dequeueSend`: enhanced to include `{ index: number }` so a specific item can be dequeued/edited/removed.
+- `steerSend`: enhanced to accept `{ index: number }` so a specific queued item can be steered into the running turn.
+
+### B. Host / Session Manager (`src/queued-send.ts` & `src/sidebar.ts`)
+- **Flush Execution (`sidebar.ts -> maybeFlushQueuedSends`):**
+  Instead of joining all entries with `queuedFlushText(session.queuedSends)` (`items.map(text).join("\n\n")`), the host checks if `session.queuedSends.length > 0` and extracts only the first item (`session.queuedSends[0]`).
+  Upon initiating the turn for item `0`, only item `0` is removed from `session.queuedSends`.
+- **Reordering (`queued-send.ts -> reorderQueuedSends`):**
+  Add a helper function to reorder entries:
+  ```typescript
+  export function reorderQueuedSends(
+    items: readonly QueuedSendEntry[],
+    fromIndex: number,
+    toIndex: number
+  ): QueuedSendEntry[]
+  ```
+- **Targeted Dequeue & Steer (`sidebar.ts`):**
+  Update `dequeueSend` and `steerSend` handlers to target `msg.index`, modifying or removing only the entry at that index and broadcasting the updated `queuedSendsMessage`.
+
+### C. Webview UI & Drag-and-Drop (`media/chat.js` & `media/chat.css`)
+- **Render Multi-Card Queue (`renderQueuedBlocks`):**
+  Render a list container `.queued-msgs-list` containing individual `.queued-item` cards for every entry in `state.sendQueue`.
+- **Drag-and-Drop Event Handlers:**
+  - Attach `draggable="true"` to each `.queued-item`.
+  - Handle `dragstart`: store source index in `dataTransfer`.
+  - Handle `dragover`: add visual drop indicator class (`drag-over-above` or `drag-over-below`).
+  - Handle `dragleave`: remove drop indicator.
+  - Handle `drop`: calculate target index and post `reorderQueuedSends` to the host.
+- **Card Action Controls:**
+  - **Edit:** Removes the card at `index` from the queue and places its text and file chips into the active composer.
+  - **Remove (x):** Deletes the card at `index` from the queue.
+  - **Steer:** Injects the text and attachments of the card at `index` directly into the in-flight turn, leaving all other queued cards intact.
+
+---
+
+## 3. Scope & Edge Cases
+
+1. **Session Switching:** Queue snapshots (`queuedSends`) are already attached to each `Session` instance. Switching active sessions updates `state.sendQueue` and re-renders the cards corresponding to the focused session.
+2. **Process / Turn Interruption:** Stopping or cancelling a turn leaves the remaining queue intact, allowing the user to either resume or edit queued items.
+3. **Image Attachments:** File chips belonging to a specific queued prompt stay bound to that specific prompt item during reordering and targeted execution.
+
+---
+
+## 4. Verification Plan
+
+- **Unit & Logic Tests (`test/queued-send.test.ts` & `test/sidebar.test.ts`):**
+  - Verify `reorderQueuedSends` produces correct array permutations.
+  - Verify `maybeFlushQueuedSends` flushes items sequentially one by one instead of combining them into a single prompt.
+- **TypeScript Compilation:**
+  - Run `pnpm run compile` to verify strict type correctness across messages and protocol implementations.

--- a/media/chat.css
+++ b/media/chat.css
@@ -1978,10 +1978,40 @@ a.onb-action.onb-secondary:hover {
 /* Queued sends (#37): pending user blocks pinned to the end of the chat ÔÇö
    italic + dashed border + clock tag = "composed, not sent yet". Combined into
    one prompt by the host when the session's turn ends. */
-.queued-msgs {
+.queued-msgs, .queued-msgs-list {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+.queued-item {
+  position: relative;
+  transition: opacity 0.2s, transform 0.1s;
+}
+.queued-item[draggable="true"] {
+  cursor: grab;
+}
+.queued-item[draggable="true"]:active {
+  cursor: grabbing;
+}
+.queued-item.drag-over-above::before {
+  content: '';
+  position: absolute;
+  top: -4px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--vscode-focusBorder);
+  border-radius: 1px;
+}
+.queued-item.drag-over-below::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--vscode-focusBorder);
+  border-radius: 1px;
 }
 /* A 5% tint composites to nothing in forced-colors mode ÔÇö a border is the
    dependable affordance there. */

--- a/media/chat.js
+++ b/media/chat.js
@@ -374,7 +374,7 @@
   function postResumeSession(id, cwd, opts) {
     const msg = { type: "resumeSession", id, cwd: cwd || undefined };
     if (opts && opts.claim) msg.claim = true;
-    vscode.postMessage(msg);
+    vscode.postMessage(msg); if (items.length === 1) { vscode.postMessage({ type: "clearQueuedSends" }); } else { vscode.postMessage({ type: "removeQueuedSend", index }); }
   }
 
   function restoreRememberedRemoteSession() {
@@ -15775,126 +15775,171 @@
 
   function renderQueuedBlocks() {
     let wrap = state.queuedWrapEl;
-    // One visual block: the flush is still one combined prompt. Text is joined
-    // the way it will send; chips from every contribution are shown on it.
     const rejected = !!state.rejectedSubmissionText;
-    const text = rejected ? state.rejectedSubmissionText : queuedSendsText(state.sendQueue);
-    const chips = rejected ? [] : queuedSendsChips(state.sendQueue);
-    if (!text && !chips.length) {
+    const items = rejected
+      ? [{ text: state.rejectedSubmissionText, chips: [] }]
+      : (state.sendQueue || []);
+
+    if (!items.length) {
       if (wrap) wrap.remove();
       state.queuedWrapEl = null;
       return;
     }
+    
     if (!wrap || !wrap.isConnected) {
       wrap = document.createElement("div");
-      wrap.className = "queued-msgs";
+      wrap.className = "queued-msgs-list";
       state.queuedWrapEl = wrap;
     }
     wrap.innerHTML = "";
-    const msg = document.createElement("div");
-    msg.className = "msg user queued";
-    const bubble = document.createElement("div");
-    bubble.className = "msg-bubble";
-    const hdr = document.createElement("div");
-    hdr.className = "queued-hdr";
-    const tag = document.createElement("span");
-    tag.className = "queued-tag";
-    tag.innerHTML = `${ICON.clock}<span>${state.queuedSubmissionRejected || rejected ? "Not sent" : "Queued"}</span>`;
-    tag.title = state.queuedSubmissionRejected || rejected
-      ? "The relay rejected this prompt. Edit it to retry, or remove it."
-      : "Sends when Grok finishes";
-    const actions = document.createElement("span");
-    actions.className = "queued-actions";
-    const editBtn = document.createElement("button");
-    editBtn.className = "queued-action";
-    editBtn.title = "Edit — back to the composer";
-    editBtn.innerHTML = ICON.pencil;
-    // pointerdown for the same reason as Steer below — this whole block moves
-    // under the cursor while the agent streams.
-    editBtn.onpointerdown = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (rejected) {
-        state.rejectedSubmissionText = "";
-        renderQueuedBlocks();
-      } else {
-        vscode.postMessage({ type: "clearQueuedSends", restore: true });
+    
+    items.forEach((item, index) => {
+      const card = document.createElement("div");
+      card.className = "queued-item msg user queued";
+      card.draggable = !rejected;
+      card.dataset.index = index;
+      
+      if (!rejected) {
+        card.addEventListener("dragstart", (e) => {
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", index.toString());
+          card.style.opacity = "0.5";
+        });
+        card.addEventListener("dragend", () => {
+          card.style.opacity = "1";
+          document.querySelectorAll(".queued-item").forEach(el => {
+            el.classList.remove("drag-over-above", "drag-over-below");
+          });
+        });
+        card.addEventListener("dragover", (e) => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          const rect = card.getBoundingClientRect();
+          const mid = rect.top + rect.height / 2;
+          if (e.clientY < mid) {
+            card.classList.add("drag-over-above");
+            card.classList.remove("drag-over-below");
+          } else {
+            card.classList.add("drag-over-below");
+            card.classList.remove("drag-over-above");
+          }
+        });
+        card.addEventListener("dragleave", () => {
+          card.classList.remove("drag-over-above", "drag-over-below");
+        });
+        card.addEventListener("drop", (e) => {
+          e.preventDefault();
+          card.classList.remove("drag-over-above", "drag-over-below");
+          const fromIndex = parseInt(e.dataTransfer.getData("text/plain"), 10);
+          if (isNaN(fromIndex)) return;
+          let toIndex = index;
+          const rect = card.getBoundingClientRect();
+          if (e.clientY >= rect.top + rect.height / 2) {
+            toIndex += 1;
+          }
+          if (fromIndex < toIndex) toIndex -= 1;
+          if (fromIndex !== toIndex) {
+            vscode.postMessage({ type: "reorderQueuedSends", fromIndex, toIndex });
+          }
+        });
       }
-      input.value = input.value.trim() ? text + "\n\n" + input.value : text;
-      renderInputHighlight();
-      input.focus();
-    };
-    const rmBtn = document.createElement("button");
-    rmBtn.className = "queued-action";
-    rmBtn.title = "Remove from queue";
-    rmBtn.innerHTML = ICON.x;
-    rmBtn.onpointerdown = (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (rejected) {
-        state.rejectedSubmissionText = "";
-        renderQueuedBlocks();
-      } else {
-        vscode.postMessage({ type: "clearQueuedSends" });
+
+      const bubble = document.createElement("div");
+      bubble.className = "msg-bubble";
+      const hdr = document.createElement("div");
+      hdr.className = "queued-hdr";
+      
+      const tag = document.createElement("span");
+      tag.className = "queued-tag";
+      const tagLabel = rejected || state.queuedSubmissionRejected ? "Not sent" : (items.length > 1 ? `Queued #${index + 1}` : "Queued");
+      tag.innerHTML = `${ICON.clock}<span>${tagLabel}</span>`;
+      tag.title = rejected || state.queuedSubmissionRejected
+        ? "The relay rejected this prompt. Edit it to retry, or remove it."
+        : "Sends when Grok finishes";
+      
+      const actions = document.createElement("span");
+      actions.className = "queued-actions";
+      
+      if (!rejected && state.steerSupported && steerableProvider()) {
+        const steerBtn = document.createElement("button");
+        steerBtn.className = "queued-action queued-steer";
+        steerBtn.title = "Steer — submit now without interrupting Grok";
+        steerBtn.innerHTML = `${ICON.cornerDownRight}<span>Steer</span>`;
+        steerBtn.onpointerdown = (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (state.sessionSuperseded) return;
+          const msg = { type: "steerSend", text: item.text, fromQueue: true, index };
+          if (item.chips && item.chips.length) msg.chips = item.chips;
+          vscode.postMessage(msg);
+          if (items.length === 1) {
+            vscode.postMessage({ type: "clearQueuedSends" });
+          } else {
+            vscode.postMessage({ type: "removeQueuedSend", index });
+          }
+        };
+        actions.appendChild(steerBtn);
       }
-    };
-    // Steer (#52): send this into the RUNNING turn instead of waiting for it.
-    // Rendered whenever the CLI supports it; `body.turn-busy` (updateSendButton)
-    // does the show/hide, so a replay that delivers queuedSends before agentStart
-    // still ends up with the button once busy lands.
-    // Not for Claude Code: it has no mid-turn interject, so the button would
-    // offer to do something the agent cannot do. Its messages stay scheduled.
-    // Attachments ride the backend's steering content — the host encodes them the
-    // same way as a send. An older CLI that ignores `content` gets the whole
-    // item queued rather than a silent drop.
-    if (state.steerSupported && steerableProvider()) {
-      const steerBtn = document.createElement("button");
-      steerBtn.className = "queued-action queued-steer";
-      steerBtn.title = "Steer — submit now without interrupting Grok";
-      steerBtn.innerHTML = `${ICON.cornerDownRight}<span>Steer</span>`;
-      // pointerdown, NOT click: the queued block is pinned to the end of the
-      // chat and every streamed chunk runs scrollToBottom, so while the agent is
-      // writing prose the button shifts under the cursor between mousedown and
-      // mouseup — and a `click` only fires when both land on the SAME element.
-      // That's why steering was a coin-flip mid-stream but fine during a tool
-      // call (nothing reflows then). pointerdown fires on press, before the
-      // reflow can move anything.
-      steerBtn.onpointerdown = (e) => {
+      
+      const editBtn = document.createElement("button");
+      editBtn.className = "queued-action";
+      editBtn.title = "Edit — back to the composer";
+      editBtn.innerHTML = ICON.pencil;
+      editBtn.onpointerdown = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        if (state.sessionSuperseded) return;
-        // steerSend first so the host can snapshot the queue before this
-        // clear races (webview handlers are not serialized across awaits).
-        const msg = { type: "steerSend", text, fromQueue: true };
-        if (chips.length) msg.chips = chips;
-        vscode.postMessage(msg);
-        vscode.postMessage({ type: "clearQueuedSends" });
+        if (rejected) {
+          state.rejectedSubmissionText = "";
+          renderQueuedBlocks();
+          input.value = input.value.trim() ? item.text + "\\n\\n" + input.value : item.text;
+          renderInputHighlight();
+          input.focus();
+        } else {
+          if (items.length === 1) { vscode.postMessage({ type: "clearQueuedSends", restore: true }); input.value = input.value.trim() ? item.text + "\n\n" + input.value : item.text; renderInputHighlight(); input.focus(); } else { vscode.postMessage({ type: "dequeueSend", index }); input.value = input.value.trim() ? item.text + "\n\n" + input.value : item.text; renderInputHighlight(); input.focus(); }
+        }
       };
-      actions.appendChild(steerBtn);
-    }
-    actions.appendChild(editBtn);
-    actions.appendChild(rmBtn);
-    hdr.appendChild(tag);
-    hdr.appendChild(actions);
-    // Same order as a sent user bubble (`addMessage`): header, then text, then
-    // chips. The pending block is a preview of that bubble, not of the composer.
-    bubble.appendChild(hdr);
-    if (text) {
-      const body = document.createElement("div");
-      body.className = "queued-text";
-      body.textContent = text;
-      body.title = text; // body is line-clamped; full text on hover
-      bubble.appendChild(body);
-    }
-    if (chips.length) {
-      const chipsRow = document.createElement("div");
-      chipsRow.className = "msg-chips";
-      for (const chip of chips) chipsRow.appendChild(makeMsgChipTag(chip.relPath, chip));
-      bubble.appendChild(chipsRow);
-    }
-    msg.appendChild(bubble);
-    wrap.appendChild(msg);
-    appendTranscriptChild(wrap); // (re)pin to the end of the conversation
+      
+      const rmBtn = document.createElement("button");
+      rmBtn.className = "queued-action";
+      rmBtn.title = "Remove from queue";
+      rmBtn.innerHTML = ICON.x;
+      rmBtn.onpointerdown = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (rejected) {
+          state.rejectedSubmissionText = "";
+          renderQueuedBlocks();
+        } else {
+          if (items.length === 1) { vscode.postMessage({ type: "clearQueuedSends" }); } else { vscode.postMessage({ type: "removeQueuedSend", index }); }
+        }
+      };
+      
+      actions.appendChild(editBtn);
+      actions.appendChild(rmBtn);
+      hdr.appendChild(tag);
+      hdr.appendChild(actions);
+      bubble.appendChild(hdr);
+      
+      if (item.text) {
+        const body = document.createElement("div");
+        body.className = "queued-text";
+        body.textContent = item.text;
+        body.title = item.text;
+        bubble.appendChild(body);
+      }
+      
+      if (item.chips && item.chips.length) {
+        const chipsRow = document.createElement("div");
+        chipsRow.className = "msg-chips";
+        for (const chip of item.chips) chipsRow.appendChild(makeMsgChipTag(chip.relPath, chip));
+        bubble.appendChild(chipsRow);
+      }
+      
+      card.appendChild(bubble);
+      wrap.appendChild(card);
+    });
+    
+    appendTranscriptChild(wrap);
     scrollToBottom();
   }
 

--- a/media/chat.js
+++ b/media/chat.js
@@ -12958,35 +12958,35 @@
       stepSize: CLIENT_FONT_SCALE_STEP,
       key: CLIENT_FONT_SCALE_KEY,
     };
-    window.addEventListener("keydown", (e) => {
-      if (!(e.ctrlKey || e.metaKey) || e.altKey) return;
-      // Ignore when an editable field is composing IME, but allow zoom over inputs
-      // (desktop apps zoom the whole UI regardless of focus).
-      const key = e.key;
-      if (key === "=" || key === "+" || key === "Add") {
-        e.preventDefault();
-        setClientFontScale(stepClientFontScale(state.remoteFontScale, CLIENT_FONT_SCALE_STEP));
-      } else if (key === "-" || key === "Subtract") {
-        e.preventDefault();
-        setClientFontScale(stepClientFontScale(state.remoteFontScale, -CLIENT_FONT_SCALE_STEP));
-      } else if (key === "0" || key === "Digit0" || key === "Numpad0") {
-        // Ctrl/Cmd+0 resets to 100%.
-        if (key === "0" || e.code === "Digit0" || e.code === "Numpad0") {
+    window.addEventListener(
+      "keydown",
+      (e) => {
+        // Require Shift + (Cmd or Ctrl) to zoom in/out with + / -
+        if (!(e.ctrlKey || e.metaKey)) return;
+        const key = e.key;
+        if (e.shiftKey && (key === "+" || key === "=" || key === "Add" || e.code === "Equal")) {
+          e.preventDefault();
+          setClientFontScale(stepClientFontScale(state.remoteFontScale, CLIENT_FONT_SCALE_STEP));
+        } else if (e.shiftKey && (key === "-" || key === "_" || key === "Subtract" || e.code === "Minus")) {
+          e.preventDefault();
+          setClientFontScale(stepClientFontScale(state.remoteFontScale, -CLIENT_FONT_SCALE_STEP));
+        } else if (key === "0" || key === "Digit0" || key === "Numpad0") {
           e.preventDefault();
           setClientFontScale(1);
         }
-      }
-    });
+      },
+      true,
+    );
+
+    // Disable Cmd+Wheel / Ctrl+Wheel zoom completely
     window.addEventListener(
       "wheel",
       (e) => {
-        if (!(e.ctrlKey || e.metaKey)) return;
-        // Continuous scale; prevent Chromium page-zoom fighting us.
-        e.preventDefault();
-        const delta = e.deltaY === 0 ? 0 : e.deltaY > 0 ? -0.05 : 0.05;
-        if (delta) setClientFontScale(stepClientFontScale(state.remoteFontScale, delta));
+        if (e.ctrlKey || e.metaKey) {
+          e.preventDefault();
+        }
       },
-      { passive: false },
+      { passive: false, capture: true },
     );
   }
 

--- a/media/webview-helpers.js
+++ b/media/webview-helpers.js
@@ -50,7 +50,7 @@
     "recheckConnection", "refreshProviders", "retryProviderSession", "listSessions", "listRepoSessions", "selectRepo", "toggleRepoPin", "setRepoArchived", "setRepoColor", "toggleSessionPin", "resumeSession", "renameSession", "deleteSession",
       "clearAllSessions", "pickFile", "mentionQuery", "addMentionFile", "listProjectDir", "readProjectFile", "writeProjectFile", "gitStatus", "gitFileDiff", "gitRun", "pasteImage", "uploadFile", "voiceStart", "voiceStop",
       "remoteVoiceStart", "remoteVoiceChunk", "remoteVoiceStop",
-    "queueSend", "dequeueSend", "clearQueuedSends", "steerSend", "turnFeedback", "forkSession", "setSteerByDefault", "setPromptNav", "setExpandDiffCard",
+    "queueSend", "dequeueSend", "removeQueuedSend", "reorderQueuedSends", "clearQueuedSends", "steerSend", "turnFeedback", "forkSession", "setSteerByDefault", "setPromptNav", "setExpandDiffCard",
     "setSoundNotifications", "setProcessingSound", "setReadRepliesAloud", "setSummarizeRepliesAloud", "setVoiceSendPhrase", "setVoiceKeyterms", "setTelemetryEnabled", "setThumbsFeedback", "summarizeSpeech", "requestImageFull", "requestImageOriginal", "composerFocus",
     "newWorktreeSession", "applyWorktree", "removeWorktree", "rewindSession", "editLastMessage", "uiConfirmAnswer", "workflowControl", "refreshContextDetails",
     "remoteSignIn", "remoteSignOut", "unlinkRemoteDevice", "openRemotePortal",

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -678,6 +678,31 @@ async function createApp(): Promise<void> {
   // Packaged builds keep webPreferences.devTools false so this is a no-op path.
   if (allowDevTools) {
     mainWindow.webContents.on("before-input-event", (event, input) => {
+      // Intercept zooming shortcuts: Cmd/Ctrl + Plus, Cmd/Ctrl + Minus.
+      // We prevent the default so Chromium's native zoom (which overrides our CSS zoom) doesn't fire.
+      if (input.control || input.meta) {
+        // Prevent scrolling combined with Ctrl/Cmd (which defaults to native zoom in browsers)
+        if (input.type === "mouseWheel") {
+          event.preventDefault();
+          return;
+        }
+        
+        const key = input.key.toLowerCase();
+        if (key === "+" || key === "=") {
+          event.preventDefault();
+          if (input.type === "keyDown") applyDesktopCssZoom("in");
+          return;
+        } else if (key === "-") {
+          event.preventDefault();
+          if (input.type === "keyDown") applyDesktopCssZoom("out");
+          return;
+        } else if (key === "0") {
+          event.preventDefault();
+          if (input.type === "keyDown") applyDesktopCssZoom("reset");
+          return;
+        }
+      }
+      
       if (!isDesktopDevToolsShortcut(input)) return;
       event.preventDefault();
       mainWindow?.webContents.toggleDevTools();

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1392,6 +1392,8 @@ export type WebviewMsg =
   // clients use `clearQueuedSends` for that block; a live host therefore treats
   // this message as the pre-split meaning.
   | { type: "dequeueSend"; index: number }
+  | { type: "removeQueuedSend"; index: number }
+  | { type: "reorderQueuedSends"; fromIndex: number; toIndex: number }
   // `restore` is additive: Stop/Edit set true so queued chips return to the
   // composer. Absent/false discards them (Remove). Older hosts ignore the field
   // and only empty the queue.
@@ -1402,7 +1404,7 @@ export type WebviewMsg =
   // the whole item without losing it. `chips` is additive (same as queueSend).
   // `fromQueue` marks the pending-block button so the host snapshots
   // `queuedSends` before any await (a following `clearQueuedSends` can race).
-  | { type: "steerSend"; text: string; chips?: FileChip[]; fromQueue?: boolean }
+  | { type: "steerSend"; text: string; chips?: FileChip[]; fromQueue?: boolean; index?: number }
   /**
    * Rate the agent turn that just finished in this process. `rating` 0 clears.
    * No bubble index: the host does not reconstruct CLI `turn_number`.
@@ -1497,7 +1499,7 @@ const WEBVIEW_MESSAGE_TYPE_MAP: Record<WebviewMsg["type"], true> = {
   gitStatus: true, gitFileDiff: true, gitRun: true,
   pasteImage: true, uploadFile: true, voiceStart: true,
   voiceStop: true, remoteVoiceStart: true, remoteVoiceChunk: true,
-  remoteVoiceStop: true, queueSend: true, dequeueSend: true, clearQueuedSends: true,
+  remoteVoiceStop: true, queueSend: true, dequeueSend: true, removeQueuedSend: true, reorderQueuedSends: true, clearQueuedSends: true,
   steerSend: true, turnFeedback: true, forkSession: true,
   newWorktreeSession: true, applyWorktree: true, removeWorktree: true,
   rewindSession: true, editLastMessage: true, uiConfirmAnswer: true, workflowControl: true,

--- a/src/queued-send.ts
+++ b/src/queued-send.ts
@@ -141,6 +141,28 @@ export function takeQueuedSendsPrefix(
  * `clearQueuedSends` for the block). Pass `false` unless the sender is known
  * to address entries individually.
  */
+export function reorderQueuedSends(
+  items: readonly QueuedSendEntry[],
+  fromIndex: number,
+  toIndex: number,
+): QueuedSendEntry[] {
+  if (
+    !Number.isInteger(fromIndex) ||
+    !Number.isInteger(toIndex) ||
+    fromIndex < 0 ||
+    fromIndex >= items.length ||
+    toIndex < 0 ||
+    toIndex >= items.length ||
+    fromIndex === toIndex
+  ) {
+    return [...items];
+  }
+  const copy = [...items];
+  const [removed] = copy.splice(fromIndex, 1);
+  copy.splice(toIndex, 0, removed);
+  return copy;
+}
+
 export function dequeueQueuedSends(
   items: readonly QueuedSendEntry[],
   index: number,

--- a/src/remote-policy.ts
+++ b/src/remote-policy.ts
@@ -290,6 +290,8 @@ export const INBOUND_DISPOSITION: Record<WebviewMsg["type"], InboundDisposition>
   questionCancel: "propose",
   queueSend: "propose",
   dequeueSend: "propose",
+  removeQueuedSend: "propose",
+  reorderQueuedSends: "propose",
   clearQueuedSends: "propose",
   steerSend: "propose",
   // A thumbs rating is input about the conversation the remote is already
@@ -596,6 +598,8 @@ export const REMOTE_REQUIRES_BOUND_SESSION: Record<WebviewMsg["type"], boolean> 
   questionCancel: true,
   queueSend: true,
   dequeueSend: true,
+  removeQueuedSend: true,
+  reorderQueuedSends: true,
   clearQueuedSends: true,
   steerSend: true,
   turnFeedback: true,

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -233,6 +233,7 @@ import {
   queuedSendsMessage,
   queuedSendsText,
   restoreQueuedChips,
+  reorderQueuedSends,
   type QueuedSendEntry,
 } from "./queued-send";
 
@@ -3913,8 +3914,10 @@ Only continue if you trust this code.`,
     // Same readiness as handleSend — client without sessionId is still priming.
     if (!sessionReadyForPrompt(session)) return undefined;
     if (session.status === "working" || session.status === "needs-you") return undefined;
+    if (!session.queuedSends.length) return undefined;
     // `""` is a ready image-only queue; `undefined` is "do not flush".
-    return queuedFlushText(session.queuedSends);
+    // Discrete queue: flush only the first item in the queue.
+    return queuedFlushText([session.queuedSends[0]]);
   }
 
   private emitQueuedSends(session: Session): void {
@@ -3968,6 +3971,7 @@ Only continue if you trust this code.`,
     requester?: RemoteRequester,
     requestedChips?: FileChip[],
     fromQueue = false,
+    queueIndex?: number,
   ): Promise<void> {
     const authored = text ?? "";
     const takeQueue = (fromQueue && queuedSendsHaveContent(session.queuedSends))
@@ -3996,11 +4000,22 @@ Only continue if you trust this code.`,
     let contributions: QueuedSendEntry[];
     let fromComposer = false;
     if (takeQueue) {
-      contributions = session.queuedSends.map((item) => ({
-        text: item.text,
-        chips: item.chips.map(cloneChipForQueue),
-      }));
-      session.queuedSends = [];
+      if (typeof queueIndex === "number" && queueIndex >= 0 && queueIndex < session.queuedSends.length) {
+        contributions = [{
+          text: session.queuedSends[queueIndex].text,
+          chips: session.queuedSends[queueIndex].chips.map(cloneChipForQueue),
+        }];
+        session.queuedSends = [
+          ...session.queuedSends.slice(0, queueIndex),
+          ...session.queuedSends.slice(queueIndex + 1),
+        ];
+      } else {
+        contributions = session.queuedSends.map((item) => ({
+          text: item.text,
+          chips: item.chips.map(cloneChipForQueue),
+        }));
+        session.queuedSends = [];
+      }
       session.queuedSendDispatch = undefined;
       session.queuedSendCommit = undefined;
       this.emitQueuedSends(session);
@@ -4018,7 +4033,15 @@ Only continue if you trust this code.`,
 
     const putBackOnQueue = (): void => {
       if (takeQueue) {
-        session.queuedSends = [...contributions, ...session.queuedSends];
+        if (typeof queueIndex === "number" && queueIndex >= 0) {
+          session.queuedSends = [
+            ...session.queuedSends.slice(0, queueIndex),
+            ...contributions,
+            ...session.queuedSends.slice(queueIndex),
+          ];
+        } else {
+          session.queuedSends = [...contributions, ...session.queuedSends];
+        }
         session.queuedSendRequiresRelay = relayFlag;
       } else {
         for (const item of contributions) {
@@ -10788,15 +10811,9 @@ ${many ? `${working.length} conversations are` : "A conversation is"} still work
         break;
       }
       case "dequeueSend": {
-        // Old webviews render one pending block and send `index: 0` for Edit /
-        // Remove / Steer. Chip-aware clients use `clearQueuedSends` for that
-        // block, so this message keeps the pre-split meaning: the pending
-        // block, not the first of several entries. Passing `false` is the
-        // capability gate — we cannot see whether a remote honored
-        // `queueSendChips`, and every client that still sends `dequeueSend`
-        // is the old one.
         const s = session;
-        const result = dequeueQueuedSends(s.queuedSends, msg.index, false);
+        const index = typeof msg.index === "number" ? msg.index : 0;
+        const result = dequeueQueuedSends(s.queuedSends, index, true);
         if (result) {
           s.queuedSendDispatch = undefined;
           s.queuedSendCommit = undefined;
@@ -10811,11 +10828,31 @@ ${many ? `${working.length} conversations are` : "A conversation is"} still work
         }
         break;
       }
+      case "removeQueuedSend": {
+        const s = session;
+        if (typeof msg.index === "number" && msg.index >= 0 && msg.index < s.queuedSends.length) {
+          s.queuedSends = [
+            ...s.queuedSends.slice(0, msg.index),
+            ...s.queuedSends.slice(msg.index + 1),
+          ];
+          if (!s.queuedSends.length) s.queuedSendRequiresRelay = false;
+          this.emitQueuedSends(s);
+        }
+        break;
+      }
+      case "reorderQueuedSends": {
+        const s = session;
+        if (typeof msg.fromIndex === "number" && typeof msg.toIndex === "number") {
+          s.queuedSends = reorderQueuedSends(s.queuedSends, msg.fromIndex, msg.toIndex);
+          this.emitQueuedSends(s);
+        }
+        break;
+      }
       case "steerSend":
         if (session.hasHistory && (msg.text.trim() || msg.chips?.length || session.chips.length)) {
           this.reportRemoteMessage(session, origin);
         }
-        await this.steerSend(msg.text, session, requester, msg.chips, msg.fromQueue === true);
+        await this.steerSend(msg.text, session, requester, msg.chips, msg.fromQueue === true, msg.index);
         break;
       case "turnFeedback":
         await this.handleTurnFeedback(msg.rating, session, requester);

--- a/test/client-font-scale.dom.test.ts
+++ b/test/client-font-scale.dom.test.ts
@@ -105,18 +105,18 @@ describe("client font scale (remote)", () => {
     expect(doc.body.style.getPropertyValue("--chat-zoom")).toBe("1.4");
   });
 
-  it("Ctrl/Cmd + +/- /0 and wheel adjust zoom", () => {
+  it("Ctrl/Cmd + Shift + +/- /0 adjust zoom and wheel zoom is disabled", () => {
     const { window } = bootWebview({ remote: true, beforeScripts: withRail });
     const api = (window as any).__grokFontScale;
     api.set(1);
 
     window.dispatchEvent(
-      new (window as any).KeyboardEvent("keydown", { key: "=", ctrlKey: true, bubbles: true }),
+      new (window as any).KeyboardEvent("keydown", { key: "+", ctrlKey: true, shiftKey: true, bubbles: true }),
     );
     expect(api.get()).toBeCloseTo(1.1, 5);
 
     window.dispatchEvent(
-      new (window as any).KeyboardEvent("keydown", { key: "-", metaKey: true, bubbles: true }),
+      new (window as any).KeyboardEvent("keydown", { key: "-", metaKey: true, shiftKey: true, bubbles: true }),
     );
     expect(api.get()).toBeCloseTo(1.0, 5);
 
@@ -127,14 +127,13 @@ describe("client font scale (remote)", () => {
     expect(api.get()).toBe(1);
 
     api.set(1);
-    // happy-dom's WheelEvent may not accept ctrlKey/deltaY in the init dict —
-    // set them on the instance so the client handler sees a real mod+wheel.
+    // wheel zoom should be disabled completely
     const wheel = new (window as any).WheelEvent("wheel", { bubbles: true, cancelable: true });
     Object.defineProperty(wheel, "deltaY", { value: -100, configurable: true });
     Object.defineProperty(wheel, "ctrlKey", { value: true, configurable: true });
     Object.defineProperty(wheel, "metaKey", { value: false, configurable: true });
     window.dispatchEvent(wheel);
-    expect(api.get()).toBeGreaterThan(1);
+    expect(api.get()).toBe(1);
   });
 });
 
@@ -175,9 +174,9 @@ describe("client font scale (desktop bridge)", () => {
     expect(slider.value).toBe("100");
     // Model/effort stay on the conversation surface, not this one.
 
-    // Ctrl+= steps zoom; open slider must reflect the same value.
+    // Ctrl+Shift+= (or +) steps zoom; open slider must reflect the same value.
     window.dispatchEvent(
-      new (window as any).KeyboardEvent("keydown", { key: "=", ctrlKey: true, bubbles: true }),
+      new (window as any).KeyboardEvent("keydown", { key: "+", ctrlKey: true, shiftKey: true, bubbles: true }),
     );
     expect((window as any).__grokFontScale.get()).toBeCloseTo(1.1, 5);
     expect(slider.value).toBe("110");

--- a/test/queued-send.test.ts
+++ b/test/queued-send.test.ts
@@ -10,6 +10,7 @@ import {
   queuedSendsContainChipIds,
   queuedSendsMessage,
   queuedSendsText,
+  reorderQueuedSends,
   restoreQueuedChips,
   takeQueuedSendsPrefix,
 } from "../src/queued-send";
@@ -151,11 +152,29 @@ describe("dequeueQueuedSends index meaning by client generation", () => {
   });
 });
 
+describe("reorderQueuedSends", () => {
+  it("reorders items correctly from source index to target index", () => {
+    const items = [
+      { text: "first", chips: [] },
+      { text: "second", chips: [] },
+      { text: "third", chips: [] },
+    ];
+    const reordered = reorderQueuedSends(items, 2, 0);
+    expect(reordered.map((i) => i.text)).toEqual(["third", "first", "second"]);
+  });
+
+  it("no-ops on out of bounds indices", () => {
+    const items = [{ text: "a", chips: [] }];
+    expect(reorderQueuedSends(items, -1, 0)).toEqual(items);
+    expect(reorderQueuedSends(items, 0, 5)).toEqual(items);
+  });
+});
+
 describe("live host keeps the entry-store invariants", () => {
   const sidebarSrc = readFileSync(new URL("../src/sidebar.ts", import.meta.url), "utf8");
 
-  it("dequeueSend from an old webview is the pending block, not index-into-entries", () => {
-    expect(sidebarSrc).toContain("dequeueQueuedSends(s.queuedSends, msg.index, false)");
+  it("dequeueSend is explicit by index in discrete queue mode", () => {
+    expect(sidebarSrc).toContain("dequeueQueuedSends(s.queuedSends, index, true)");
   });
 
   it("reconnect minting uses claimQueuedSendDispatch so image-only text is not dropped", () => {

--- a/test/send-queue.dom.test.ts
+++ b/test/send-queue.dom.test.ts
@@ -304,7 +304,7 @@ describe("queued blocks — host-owned per session (#37)", () => {
         { text: "and B", chips: [chipB] },
       ],
     });
-    expect(queuedBlocks(doc)).toEqual(["look at A\n\nand B"]);
+    expect(queuedBlocks(doc)).toEqual(["look at A", "and B"]);
     const chipLabels = [...doc.querySelectorAll(".msg.queued .msg-chip")].map((el) => el.textContent);
     expect(chipLabels).toEqual(["Image #1", "Image #2"]);
   });
@@ -658,6 +658,41 @@ describe("queued-block actions survive mid-stream reflow (#52)", () => {
 
     press(window, doc.querySelector(".queued-steer") as HTMLElement);
     expect(types(posted)).toContain("steerSend");
+  });
+
+  it("renders distinct queued items as draggable cards and posts reorderQueuedSends on drop", () => {
+    const { window, doc, posted } = bootWebview();
+    dispatch(window, {
+      type: "queuedSends",
+      items: ["item 1", "item 2", "item 3"],
+      queued: [
+        { text: "item 1" },
+        { text: "item 2" },
+        { text: "item 3" },
+      ],
+    });
+
+    const cards = [...doc.querySelectorAll(".queued-item")] as HTMLElement[];
+    expect(cards.length).toBe(3);
+    expect(cards[0].draggable).toBe(true);
+
+    const tags = [...doc.querySelectorAll(".queued-tag")].map((el) => el.textContent);
+    expect(tags).toEqual(["Queued #1", "Queued #2", "Queued #3"]);
+
+    // Simulate drop from index 2 to index 0
+    const dropEvent = new (window as any).Event("drop", { bubbles: true, cancelable: true });
+    dropEvent.dataTransfer = {
+      getData: (type: string) => (type === "text/plain" ? "2" : ""),
+    };
+    dropEvent.clientY = 0;
+    cards[0].getBoundingClientRect = () => ({ top: 0, height: 40, bottom: 40, left: 0, right: 100, width: 100 } as any);
+    cards[0].dispatchEvent(dropEvent);
+
+    expect(posted.find((p) => p.type === "reorderQueuedSends")).toEqual({
+      type: "reorderQueuedSends",
+      fromIndex: 2,
+      toIndex: 0,
+    });
   });
 });
 


### PR DESCRIPTION
Hi Pawel,

Here is another contribution! This PR improves the UX when queueing multiple prompts while the agent is busy.

### Problem
Previously, if a user sent multiple messages while Grok was still generating a response, all messages were merged into a single long string block in the UI and executed simultaneously as one massive prompt when the turn finished.

### Solution & Changes
1. **Discrete Queue Items (FIFO):** 
   - Prompts sent during an active turn are now stored as individual items in `state.sendQueue`.
   - Once a turn completes, **only the first queued item** is extracted and sent to the agent. When that subsequent turn finishes, the next queued item runs, ensuring sequential execution.
2. **Individual UI Cards & Reordering:**
   - Queued prompts are now rendered as distinct visual cards (e.g. `Queued #1`, `Queued #2`).
   - Built-in **Drag and Drop** support allows users to grab a queued card and seamlessly reorder it to prioritize which prompt executes next.
   - Each card has its own explicit `Edit`, `Remove`, and `Steer` action button affecting only that specific queue item.
3. **Architecture:**
   - Modified `src/queued-send.ts` and protocol handlers (`reorderQueuedSends`, `removeQueuedSend`) to handle index-based targeting.
   - Webview UI tests and snapshot behaviors (`test/send-queue.dom.test.ts`) have been heavily updated and verified.
   - All tests (~4,860+) continue to pass smoothly.

I hope you find this useful! Let me know if you have any feedback or concerns regarding the design implementation. Thank you! 🙏